### PR TITLE
disable caching for windows environments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           environment-file: environment.yml
           create-args: python=${{ matrix.python-version }}
-          cache-environment: true
+          cache-environment: ${{ matrix.os != 'windows-latest' }}
 
       - name: Install the library
         run: pip install ./


### PR DESCRIPTION
Disables the caching of conda environments on windows because it takes longer to restore them from the cache than creating them from scratch. See https://github.com/actions/cache/issues/752 for more details (TLDR: tar is slow on windows).