### PR TITLE
set orient in pl.from_numpy

### DIFF
--- a/nbs/processing.ipynb
+++ b/nbs/processing.ipynb
@@ -195,7 +195,7 @@
     "        else:\n",
     "            if isinstance(names, str):\n",
     "                names = [names]\n",
-    "            vals = pl.from_numpy(values, schema=names)\n",
+    "            vals = pl.from_numpy(values, schema=names, orient='row')\n",
     "        df = df.with_columns(vals)\n",
     "    return df"
    ]

--- a/utilsforecast/processing.py
+++ b/utilsforecast/processing.py
@@ -114,7 +114,7 @@ def assign_columns(
         else:
             if isinstance(names, str):
                 names = [names]
-            vals = pl.from_numpy(values, schema=names)
+            vals = pl.from_numpy(values, schema=names, orient="row")
         df = df.with_columns(vals)
     return df
 


### PR DESCRIPTION
Sets `orient='row'` in `pl.from_numpy` to prevent the arrays from being interpreted in column-major format.