### PR TITLE
rename polars value_counts output

### DIFF
--- a/nbs/losses.ipynb
+++ b/nbs/losses.ipynb
@@ -770,19 +770,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name '_base_docstring' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m#| export\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;129m@_base_docstring\u001b[39m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msmape\u001b[39m(\n\u001b[1;32m      4\u001b[0m     df: DataFrame,\n\u001b[1;32m      5\u001b[0m     models: List[\u001b[38;5;28mstr\u001b[39m],\n\u001b[1;32m      6\u001b[0m     id_col: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124munique_id\u001b[39m\u001b[38;5;124m'\u001b[39m,\n\u001b[1;32m      7\u001b[0m     target_col: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m,\n\u001b[1;32m      8\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Union[\u001b[38;5;28mfloat\u001b[39m, np\u001b[38;5;241m.\u001b[39mndarray]:\n\u001b[1;32m      9\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Symmetric Mean Absolute Percentage Error (SMAPE)\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \n\u001b[1;32m     11\u001b[0m \u001b[38;5;124;03m    SMAPE measures the relative prediction\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[38;5;124;03m    0% and 100% which is desirable compared to normal MAPE that\u001b[39;00m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;124;03m    may be undetermined when the target is zero.\"\"\"\u001b[39;00m\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(df, pd\u001b[38;5;241m.\u001b[39mDataFrame):\n",
-      "\u001b[0;31mNameError\u001b[0m: name '_base_docstring' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| export\n",
     "@_base_docstring\n",
@@ -847,7 +835,7 @@
        "absolute values for the prediction and observed value at a\n",
        "given time, then averages these devations over the length\n",
        "of the series. This allows the SMAPE to have bounds between\n",
-       "0% and 200% which is desireble compared to normal MAPE that\n",
+       "0% and 100% which is desirable compared to normal MAPE that\n",
        "may be undetermined when the target is zero.\n",
        "\n",
        "|    | **Type** | **Default** | **Details** |\n",
@@ -878,7 +866,7 @@
        "absolute values for the prediction and observed value at a\n",
        "given time, then averages these devations over the length\n",
        "of the series. This allows the SMAPE to have bounds between\n",
-       "0% and 200% which is desireble compared to normal MAPE that\n",
+       "0% and 100% which is desirable compared to normal MAPE that\n",
        "may be undetermined when the target is zero.\n",
        "\n",
        "|    | **Type** | **Default** | **Details** |\n",
@@ -1524,7 +1512,8 @@
     "        if isinstance(result, pd.DataFrame):\n",
     "            result = result.groupby(df[id_col], observed=True).mean()\n",
     "        else:\n",
-    "            result = group_by(result, df[id_col]).mean()\n",
+    "            result = result.with_columns(df[id_col])\n",
+    "            result = group_by(result, id_col).mean()\n",
     "        if res is None:\n",
     "            res = result\n",
     "            if isinstance(res, pd.DataFrame):\n",
@@ -1707,7 +1696,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L482){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L483){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### coverage\n",
        "\n",
@@ -1730,7 +1719,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L482){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L483){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### coverage\n",
        "\n",
@@ -1845,7 +1834,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L539){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L540){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### calibration\n",
        "\n",
@@ -1868,7 +1857,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L539){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L540){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### calibration\n",
        "\n",
@@ -1987,7 +1976,9 @@
     "\n",
     "        grouped_df = group_by(df, id_col)\n",
     "        norm = grouped_df.agg(pl.col(target_col).abs().sum().alias('norm'))\n",
-    "        sizes = df[id_col].value_counts().with_columns(pl.col('counts') * (pl.col('counts') + 1) / 2)\n",
+    "        sizes = df[id_col].value_counts()\n",
+    "        sizes.columns = [id_col, 'counts']\n",
+    "        sizes = sizes.with_columns(pl.col('counts') * (pl.col('counts') + 1) / 2)\n",
     "        res = _pl_agg_expr(loss.join(sizes, on=id_col).join(norm, on=id_col), models, id_col, gen_expr)\n",
     "    return res"
    ]
@@ -2002,7 +1993,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L589){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L590){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### scaled_crps\n",
        "\n",
@@ -2030,7 +2021,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L589){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/Nixtla/utilsforecast/blob/main/utilsforecast/losses.py#L590){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### scaled_crps\n",
        "\n",

--- a/nbs/processing.ipynb
+++ b/nbs/processing.ipynb
@@ -131,9 +131,9 @@
     "        if not id_counts.index.is_monotonic_increasing:\n",
     "            id_counts = id_counts.sort_index()\n",
     "        id_counts = id_counts.reset_index()\n",
-    "        id_counts.columns = [id_col, 'counts']\n",
     "    else:\n",
     "        id_counts = df[id_col].value_counts().sort(id_col)\n",
+    "    id_counts.columns = [id_col, 'counts']\n",
     "    return id_counts"
    ]
   },

--- a/utilsforecast/processing.py
+++ b/utilsforecast/processing.py
@@ -62,9 +62,9 @@ def counts_by_id(df: DataFrame, id_col: str) -> DataFrame:
         if not id_counts.index.is_monotonic_increasing:
             id_counts = id_counts.sort_index()
         id_counts = id_counts.reset_index()
-        id_counts.columns = [id_col, "counts"]
     else:
         id_counts = df[id_col].value_counts().sort(id_col)
+    id_counts.columns = [id_col, "counts"]
     return id_counts
 
 # %% ../nbs/processing.ipynb 8


### PR DESCRIPTION
Since polars 0.20 the output of `polars.Series.value_counts` names the counts column `count` whereas it previously was `counts`. This renames to `counts` afterwards to be compatible with the other functions that depend on that time.