### PR TITLE
remove `fastcore` based tests from pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def assert_raises_with_message(func, expected_msg, *args, **kwargs):
+    with pytest.raises((AssertionError, ValueError, Exception)) as exc_info:
+        func(*args, **kwargs)
+    assert expected_msg in str(exc_info.value)

--- a/tests/test_grouped_array.py
+++ b/tests/test_grouped_array.py
@@ -1,10 +1,10 @@
 # test _append_one
 import numpy as np
-from fastcore.test import test_eq as _test_equal
-from fastcore.test import test_fail as _test_fail
 
 from utilsforecast.data import generate_series
 from utilsforecast.grouped_array import GroupedArray, _append_one, _append_several
+
+from .conftest import assert_raises_with_message
 
 
 def test_append_one():
@@ -64,7 +64,7 @@ def test_grouped_array():
     data = np.arange(20, dtype=np.float32).reshape(-1, 2)
     indptr = np.array([0, 2, 10])  # group 1: [0, 1], group 2: [2..9]
     ga = GroupedArray(data, indptr)
-    _test_equal(len(ga), 2)
+    assert len(ga) == 2
     # Iterate through the groups
     ga_iter = iter(ga)
     np.testing.assert_equal(next(ga_iter), np.arange(4).reshape(-1, 2))
@@ -130,7 +130,7 @@ def test_grouped_array_1d():
     np.testing.assert_allclose(subset1d[0].data, ga2_1d[0].data)
     np.testing.assert_allclose(subset1d[1].data, ga2_1d[2].data)
     # try to append new values that don't match the number of groups
-    _test_fail(lambda: ga.append(np.array([1.0, 2.0, 3.0])), contains="new must have 2 rows")
+    assert_raises_with_message(lambda: ga.append(np.array([1.0, 2.0, 3.0])), "new must have 2 rows")
     # build from df
     series_pd = generate_series(10, static_as_categorical=False, engine="pandas")
     ga_pd = GroupedArray.from_sorted_df(series_pd, "unique_id", "ds", "y")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -4,11 +4,12 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pytest
-from fastcore.test import test_fail as _test_fail
 
 from utilsforecast.compat import POLARS_INSTALLED
 from utilsforecast.data import generate_series
 from utilsforecast.plotting import plot_series
+
+from .conftest import assert_raises_with_message
 
 if POLARS_INSTALLED:
     import polars as pl
@@ -112,9 +113,9 @@ def test_plotting_combinations(
     )
 
     if level is None and plot_anomalies:
-        _test_fail(fn, contains="specify the `level` argument")
+        assert_raises_with_message(fn, "specify the `level` argument")
     elif level is not None and plot_anomalies and not with_forecasts:
-        _test_fail(fn, contains="provide a `forecasts_df` with prediction")
+        assert_raises_with_message(fn, "provide a `forecasts_df` with prediction")
     else:
         with warnings.catch_warnings():
             warnings.filterwarnings(


### PR DESCRIPTION
This PR uses simple `assert`s and `pytest.raises` instead of the `fastcore.test`