### PR TITLE
no watermark in docs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build docs
         run: |
           pip install . lazydocs
-          lazydocs .utilsforecast
+          lazydocs .utilsforecast --no-watermark
           python docs/to_mdx.py
 
       - name: Deploy


### PR DESCRIPTION
This PR rebuilds the documentation without the lazydocs watermark. Assuming it will also generate `plotting.mdx`