### PR TITLE
Changes backend of matplotlib to agg instead of tinker

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,6 +26,10 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+      
+      - name: Set matplotlib backend (headless)
+        run: echo "MPLBACKEND=Agg" >> $GITHUB_ENV
+        shell: bash
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
There's an error on Python 3.13 with Windows because it doesn't have a GUI environment. Changing the default environment to agg in order to solve test.