### PR TITLE
[CHORE] Add WAPE loss (alias of nd)

### DIFF
--- a/docs/losses.html.md
+++ b/docs/losses.html.md
@@ -206,6 +206,24 @@ where must be $a\neq0$.
       show_root_heading: true
       show_source: true
 
+### Weighted Absolute Percentage Error
+
+```math
+\mathrm{WAPE}(\mathbf{y}_{\tau}, \mathbf{\hat{y}}_{\tau}) = \frac{\sum^{t+H}_{\tau=t+1} |y_{\tau} - \hat{y}_{\tau}|}{\sum^{t+H}_{\tau=t+1} | y_{\tau} |}
+```
+
+WAPE (also known as wMAPE or the MAD/Mean ratio) is mathematically identical
+to the Normalized Deviation (ND) above; it is exposed under this more common
+name for convenience.
+
+::: utilsforecast.losses.wape
+    handler: python
+    options:
+      docstring_style: google
+      heading_level: 4
+      show_root_heading: true
+      show_source: true
+
 ### Mean Squared Scaled Error
 
 ```math

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -200,6 +200,7 @@ def linex_single(y_true, y_pred, a=1.0, **kwargs):
         (ufl.msse, msse_single),
         (ufl.rmsse, rmsse_single),
         (ufl.nd, nd_single),
+        (ufl.wape, nd_single),
         (ufl.coverage, coverage_single),
         (ufl.linex, linex_single),
         (
@@ -268,6 +269,15 @@ def test_loss(engine, utils_fn, single_fn):
     expected = nw.from_native(type(series)(results)).sort("unique_id")
     actual = nw.from_native(actual).sort("unique_id")
     np.testing.assert_allclose(actual[models], expected[models])
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_wape_equals_nd(engine):
+    """WAPE is an alias of ND; both must produce identical results."""
+    series, models = setup_series(engine)
+    wape_res = nw.from_native(ufl.wape(series, models)).sort("unique_id")
+    nd_res = nw.from_native(ufl.nd(series, models)).sort("unique_id")
+    np.testing.assert_allclose(wape_res[models], nd_res[models])
 
 
 @pytest.mark.parametrize("engine", ["pandas", "polars"])

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -9,6 +9,7 @@ __all__ = [
     "pis",
     "spis",
     "mape",
+    "wape",
     "smape",
     "mase",
     "rmae",
@@ -540,6 +541,36 @@ def nd(
         )
         .sort(*group_cols)
         .to_native()
+    )
+
+
+@_base_docstring
+def wape(
+    df: IntoDataFrameT,
+    models: List[str],
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    cutoff_col: str = "cutoff",
+) -> IntoDataFrameT:
+    """Weighted Absolute Percentage Error (WAPE)
+
+    WAPE = sum(|y - ŷ|) / sum(|y|)
+
+    Unlike MAPE, which averages per-point percentage errors, WAPE normalizes
+    the total absolute error by the total absolute value of the actuals. This
+    makes it robust to zero actuals and gives more weight to higher-volume
+    points.
+
+    WAPE is mathematically identical to the Normalized Deviation (`nd`); it is
+    also known as wMAPE or the MAD/Mean ratio. It is exposed under the WAPE
+    name -- the most common name for this metric in business forecasting -- and
+    delegates to `nd`."""
+    return nd(
+        df=df,
+        models=models,
+        id_col=id_col,
+        target_col=target_col,
+        cutoff_col=cutoff_col,
     )
 
 


### PR DESCRIPTION
Adds a `wape` (Weighted Absolute Percentage Error) loss function, closes #244.

## Approach: alias of `nd`

WAPE is defined as `sum(|y - ŷ|) / sum(|y|)`, which is **mathematically identical** to the existing Normalized Deviation (`nd`) loss — verified numerically. Rather than reimplementing the same computation (as #251 does), this PR exposes `wape` as a thin, documented alias that delegates to `nd`, keeping a single source of truth and the more efficient single-pass implementation.

WAPE is the more common name for this metric in business/demand forecasting (also known as **wMAPE** or the **MAD/Mean ratio**), while `nd` is the name prevalent in the ML-forecasting literature (e.g. DeepAR). Exposing both names improves discoverability.

## Changes
- `utilsforecast/losses.py`: add `wape` to `__all__` and a `wape()` function delegating to `nd()`, with a docstring noting the equivalence and alternative names.
- `tests/test_losses.py`: add `wape` to the parametrized `test_loss` (reusing the existing `nd_single` numpy reference) and a dedicated `test_wape_equals_nd` asserting the two produce identical results across pandas and polars.
- `docs/losses.html.md`: document WAPE next to ND, making the equivalence explicit.

## Notes
- This is an alternative to #251, which adds WAPE as a standalone (duplicate) implementation. See the discussion there re: WAPE ≡ ND.
- Kept the diff minimal — no unrelated reformatting.