### PR TITLE
feat: Add Winkler score 

### DIFF
--- a/docs/losses.html.md
+++ b/docs/losses.html.md
@@ -353,6 +353,33 @@ where $\bar{y}=\frac{1}{H}\sum^{t+H}_{\tau=t+1} y_{\tau}$.
       show_root_heading: true
       show_source: true
 
+### Winkler Score
+
+```math
+\mathrm{Winkler}_{\alpha}(\mathbf{y}_{\tau}, \boldsymbol{\ell}_{\alpha,\tau}, \mathbf{u}_{\alpha,\tau}) = \frac{1}{H} \sum^{t+H}_{\tau=t+1} W_{\alpha,\tau}
+```
+
+where
+
+```math
+W_{\alpha,\tau} =
+\begin{cases}
+(u_{\alpha,\tau} - \ell_{\alpha,\tau}) + \frac{2}{\alpha} (\ell_{\alpha,\tau} - y_{\tau}) & \text{if } y_{\tau} < \ell_{\alpha,\tau} \\
+(u_{\alpha,\tau} - \ell_{\alpha,\tau}) & \text{if } \ell_{\alpha,\tau} \le y_{\tau} \le u_{\alpha,\tau} \\
+(u_{\alpha,\tau} - \ell_{\alpha,\tau}) + \frac{2}{\alpha} (y_{\tau} - u_{\alpha,\tau}) & \text{if } y_{\tau} > u_{\alpha,\tau}
+\end{cases}
+```
+
+where $[\ell_{\alpha,\tau}, u_{\alpha,\tau}]$ is the $100(1-\alpha)\%$ prediction interval and $\alpha = 1 - \text{level}/100$.
+
+::: utilsforecast.losses.winkler_score
+    handler: python
+    options:
+      docstring_style: google
+      heading_level: 4
+      show_root_heading: true
+      show_source: true
+
 ### Calibration
 
 ::: utilsforecast.losses.calibration

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -159,6 +159,17 @@ def coverage_single(y_true, y_pred_lo, y_pred_hi, **kwargs):
     return np.mean((y_true >= y_pred_lo) & (y_true <= y_pred_hi))
 
 
+def winkler_score_single(y_true, y_pred_lo, y_pred_hi, level=80, **kwargs):
+    alpha = (100 - level) / 100
+    width = y_pred_hi - y_pred_lo
+    penalty = np.where(
+        y_true < y_pred_lo,
+        (2 / alpha) * (y_pred_lo - y_true),
+        np.where(y_true > y_pred_hi, (2 / alpha) * (y_true - y_pred_hi), 0.0),
+    )
+    return np.mean(width + penalty)
+
+
 def tweedie_deviance_single(y_true, y_pred, power, **kwargs):
     if power == 0:
         return np.mean((y_true - y_pred) ** 2)
@@ -202,6 +213,7 @@ def linex_single(y_true, y_pred, a=1.0, **kwargs):
         (ufl.nd, nd_single),
         (ufl.wape, nd_single),
         (ufl.coverage, coverage_single),
+        (ufl.winkler_score, winkler_score_single),
         (ufl.linex, linex_single),
         (
             partial(ufl.linex, a=2.0),

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -1021,7 +1021,7 @@ def winkler_score(
     Args:
         df (pandas or polars DataFrame): Input dataframe with id, times, actuals and predictions.
         models (list of str): Columns that identify the models predictions.
-        level (int): Confidence level used for intervals.
+        level (int): Confidence level used for intervals. Must satisfy 0 < level < 100.
         id_col (str, optional): Column that identifies each serie. Defaults to 'unique_id'.
         target_col (str, optional): Column that contains the target. Defaults to 'y'.
         cutoff_col (str, optional): Column that identifies the cutoff point for each forecast cross-validation fold. Defaults to 'cutoff'.
@@ -1033,6 +1033,8 @@ def winkler_score(
         [1] https://otexts.com/fpppy/05-toolbox.html#winkler-score
         [2] Winkler, R. L. (1972). A decision-theoretic approach to interval estimation.
     """
+    if level <= 0 or level >= 100:
+        raise ValueError(f"`level` must satisfy 0 < level < 100, but got {level}.")
     alpha = (100 - level) / 100
 
     def gen_expr(model):

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -1043,9 +1043,7 @@ def winkler_score(
         penalty = (
             nw.when(y < lo)
             .then((2 / alpha) * (lo - y))
-            .otherwise(
-                nw.when(y > hi).then((2 / alpha) * (y - hi)).otherwise(0.0)
-            )
+            .otherwise(nw.when(y > hi).then((2 / alpha) * (y - hi)).otherwise(0.0))
         )
         return (width + penalty).alias(model)
 

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -1007,17 +1007,16 @@ def winkler_score(
 
     The Winkler score evaluates a prediction interval by rewarding narrow
     intervals and penalizing observations that fall outside them. For a
-    100(1-alpha)% prediction interval [lo, hi] and an observation y, it is
-    defined as the width of the interval plus a penalty when y lies outside it:
+    100(1-alpha)% prediction interval [lo, hi] and an observation y, with
+    alpha = 1 - level/100, it is defined as:
 
-    - (hi - lo)                          if lo <= y <= hi
-    - (hi - lo) + (2/alpha)(lo - y)      if y < lo
-    - (hi - lo) + (2/alpha)(y - hi)      if y > hi
+    - The interval width (hi - lo), if the observation lies within the interval
+      (between lo and hi, inclusive).
+    - (hi - lo) + (2/alpha)(lo - y), if the observation lies below the interval.
+    - (hi - lo) + (2/alpha)(y - hi), if the observation lies above the interval.
 
-    where alpha = 1 - level/100. Lower scores are better: intervals that are
-    both narrow and well calibrated are rewarded, while observations outside the
-    interval incur a penalty inversely proportional to alpha. The score is
-    averaged over the series.
+    Lower scores are better. Intervals that are both narrow and well calibrated
+    are rewarded, while observations outside the interval incur on a penalty.
 
     Args:
         df (pandas or polars DataFrame): Input dataframe with id, times, actuals and predictions.

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -21,6 +21,7 @@ __all__ = [
     "mqloss",
     "scaled_mqloss",
     "coverage",
+    "winkler_score",
     "calibration",
     "scaled_crps",
     "tweedie_deviance",
@@ -984,6 +985,70 @@ def coverage(
             .is_between(nw.col(f"{model}-lo-{level}"), nw.col(f"{model}-hi-{level}"))
             .alias(model)
         )
+
+    return _nw_agg_expr(
+        df=df,
+        models=models,
+        id_col=id_col,
+        gen_expr=gen_expr,
+        cutoff_col=cutoff_col,
+    )
+
+
+def winkler_score(
+    df: IntoDataFrameT,
+    models: List[str],
+    level: int,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    cutoff_col: str = "cutoff",
+) -> IntoDataFrameT:
+    """Winkler Score
+
+    The Winkler score evaluates a prediction interval by rewarding narrow
+    intervals and penalizing observations that fall outside them. For a
+    100(1-alpha)% prediction interval [lo, hi] and an observation y, it is
+    defined as the width of the interval plus a penalty when y lies outside it:
+
+    - (hi - lo)                          if lo <= y <= hi
+    - (hi - lo) + (2/alpha)(lo - y)      if y < lo
+    - (hi - lo) + (2/alpha)(y - hi)      if y > hi
+
+    where alpha = 1 - level/100. Lower scores are better: intervals that are
+    both narrow and well calibrated are rewarded, while observations outside the
+    interval incur a penalty inversely proportional to alpha. The score is
+    averaged over the series.
+
+    Args:
+        df (pandas or polars DataFrame): Input dataframe with id, times, actuals and predictions.
+        models (list of str): Columns that identify the models predictions.
+        level (int): Confidence level used for intervals.
+        id_col (str, optional): Column that identifies each serie. Defaults to 'unique_id'.
+        target_col (str, optional): Column that contains the target. Defaults to 'y'.
+        cutoff_col (str, optional): Column that identifies the cutoff point for each forecast cross-validation fold. Defaults to 'cutoff'.
+
+    Returns:
+        pandas or polars DataFrame: dataframe with one row per id and one column per model.
+
+    References:
+        [1] https://otexts.com/fpppy/05-toolbox.html#winkler-score
+        [2] Winkler, R. L. (1972). A decision-theoretic approach to interval estimation.
+    """
+    alpha = (100 - level) / 100
+
+    def gen_expr(model):
+        lo = nw.col(f"{model}-lo-{level}")
+        hi = nw.col(f"{model}-hi-{level}")
+        y = nw.col(target_col)
+        width = hi - lo
+        penalty = (
+            nw.when(y < lo)
+            .then((2 / alpha) * (lo - y))
+            .otherwise(
+                nw.when(y > hi).then((2 / alpha) * (y - hi)).otherwise(0.0)
+            )
+        )
+        return (width + penalty).alias(model)
 
     return _nw_agg_expr(
         df=df,


### PR DESCRIPTION
## Description

Adds the Winkler score as defined [here](https://otexts.com/fpppy/05-toolbox.html#winkler-score). Includes: 
- Winkler score method 
- Validation test 
- Updated documentation 

This Winkler score produces the same results as the `fable` R package. 

```python 
import pandas as pd 
from utilsforecast.losses import winkler_score
from utilsforecast.evaluation import evaluate
from statsforecast import StatsForecast
from statsforecast.models import SeasonalNaive 

df = pd.read_csv("https://raw.githubusercontent.com/Nixtla/transfer-learning-time-series/main/datasets/electricity-short.csv")

sf = StatsForecast(
    models=[SeasonalNaive(season_length=24)],
    freq='h',
    n_jobs=-1,
)

cv = sf.cross_validation(
    df=df, 
    h=24, 
    n_windows=1,
    level=[80]
)

eval_df = evaluate(
    cv, 
    metrics=[winkler_score],
    level=[80]
)
eval_df.round(1)

# unique_id | cutoff | metric | SeasonalNaive
# BE | 2016-12-29 23:00:00 | winkler_score_level80 | 95.2
# FR | 2016-12-29 23:00:00 | winkler_score_level80 | 103.1
# DE | 2017-12-29 23:00:00 | winkler_score_level80 | 59.4
# NP | 2018-12-22 23:00:00 | winkler_score_level80 | 15.3
```

```R
library(fable)
library(tidyverse)

df <- read.csv("https://raw.githubusercontent.com/Nixtla/transfer-learning-time-series/main/datasets/electricity-short.csv")

df <- df |> 
  mutate(ds = as_datetime(ds)) |> 
  as_tsibble(key = unique_id, index = ds) 

train <- df |>
  group_by(unique_id) |>
  slice(1:(n() - 24)) |>
  ungroup()

test <- df |>
  group_by(unique_id) |>
  slice_tail(n = 24) |>
  ungroup()

fc <- train |>
  model(snaive = SNAIVE(y ~ lag(24))) |>
  forecast(h = 24)

fc |>
  accuracy(test, measures = list(winkler = winkler_score), level = 80)
# .model unique_id .type winkler
# 1 snaive BE        Test     95.2
# 2 snaive DE        Test     59.4
# 3 snaive FR        Test    103.1 
# 4 snaive NP        Test     15.3
```