### PR TITLE
perf: batch evaluate metrics, vectorize grids and grouped appends

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1406,3 +1406,141 @@ def test_plot_pareto_2d_polars():
 
     import matplotlib.pyplot as plt
     plt.close("all")
+
+
+# ========================================
+# Batched simple-metric evaluation (perf)
+# ========================================
+#
+# `evaluate` batches mae/mse/rmse/bias/cfe/pis/mape/smape into a single
+# `group_by` pass instead of one per metric (see `_batch_nw_agg_expr` and
+# `_SIMPLE_METRIC_SPECS` in losses.py). These tests pin that batched path to
+# the same output a standalone call to each metric produces, on adversarial
+# inputs (zero targets, an all-zero model, NaNs, duplicated/mixed metrics).
+
+
+def _adversarial_eval_df(engine: str):
+    rng = np.random.default_rng(7)
+    n_series, n_points = 12, 9
+    ids = np.repeat([f"id_{i}" for i in range(n_series)], n_points)
+    dates = pd.date_range("2020-01-01", periods=n_points, freq="D")
+    times = np.tile(dates.values, n_series)
+    y = rng.normal(size=n_series * n_points)
+    y[::5] = 0.0  # zero targets: mape/nd/wape division edge case
+    df = pd.DataFrame({"unique_id": ids, "ds": times, "y": y})
+    for m in range(3):
+        df[f"model{m}"] = y + rng.normal(scale=0.5, size=len(df))
+    df.loc[df.index[::7], "model1"] = np.nan  # missing predictions
+    df["model2"] = 0.0  # all-zero model: smape denominator edge case
+    if engine == "polars":
+        df = pl.from_pandas(df)
+    return df
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_evaluate_batched_simple_metrics_match_direct_calls(engine):
+    df = _adversarial_eval_df(engine)
+    models = ["model0", "model1", "model2"]
+    batchable_metrics = [mae, mse, rmse, bias, cfe, pis, mape, smape]
+
+    result = evaluate(df, batchable_metrics, models=models)
+    result_nw = nw.from_native(result)
+
+    for metric in batchable_metrics:
+        direct = nw.from_native(metric(df, models=models)).sort("unique_id")
+        sub = (
+            result_nw.filter(nw.col("metric") == metric.__name__)
+            .drop("metric")
+            .sort("unique_id")
+        )
+        for model in models:
+            np.testing.assert_allclose(
+                direct[model].to_numpy().astype(float),
+                sub[model].to_numpy().astype(float),
+                equal_nan=True,
+                err_msg=f"batched evaluate() diverged from direct {metric.__name__}() call",
+            )
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_evaluate_batched_simple_metrics_with_cutoff(engine):
+    df = _adversarial_eval_df(engine)
+    n = ufp.to_numpy(df[["unique_id"]]).shape[0]
+    cutoff_vals = np.where(
+        np.arange(n) % 2 == 0,
+        np.datetime64("2020-01-01"),
+        np.datetime64("2020-01-02"),
+    )
+    df = ufp.assign_columns(df, "cutoff", cutoff_vals)
+    models = ["model0", "model1", "model2"]
+    metrics = [mae, mse, rmse, bias, cfe, pis, mape, smape]
+
+    result = evaluate(df, metrics, models=models, cutoff_col="cutoff")
+    result_nw = nw.from_native(result)
+
+    for metric in metrics:
+        direct = nw.from_native(metric(df, models=models, cutoff_col="cutoff")).sort(
+            ["unique_id", "cutoff"]
+        )
+        sub = (
+            result_nw.filter(nw.col("metric") == metric.__name__)
+            .drop("metric")
+            .sort(["unique_id", "cutoff"])
+        )
+        for model in models:
+            np.testing.assert_allclose(
+                direct[model].to_numpy().astype(float),
+                sub[model].to_numpy().astype(float),
+                equal_nan=True,
+                err_msg=f"batched evaluate() with cutoff_col diverged for {metric.__name__}()",
+            )
+
+
+def test_evaluate_batched_simple_metrics_duplicate_and_mixed():
+    """A metric requested twice, and a mix of batchable + non-batchable
+    metrics (mae/mse batched, mase not), must not corrupt each other's
+    output blocks -- guards against accidental aliasing of the cached
+    batched result across multiple `results_per_metric` entries."""
+    df = _adversarial_eval_df("pandas")
+    models = ["model0", "model1", "model2"]
+    n_series = df["unique_id"].nunique()
+
+    result = evaluate(df, [mae, mse, mae, rmse], models=models)
+    assert result.shape[0] == 4 * n_series
+    mae_blocks = result[result["metric"] == "mae"]
+    assert len(mae_blocks) == 2 * n_series
+    direct_mae = mae(df, models=models).sort_values("unique_id").reset_index(drop=True)
+    for block_start in range(0, len(mae_blocks), n_series):
+        block = (
+            mae_blocks.iloc[block_start : block_start + n_series]
+            .sort_values("unique_id")
+            .reset_index(drop=True)
+        )
+        pd.testing.assert_frame_equal(
+            block[models].reset_index(drop=True),
+            direct_mae[models].reset_index(drop=True),
+        )
+
+    result_mixed = evaluate(
+        df, [mae, partial(mase, seasonality=7), mse], models=models, train_df=df
+    )
+    direct_mase = mase(df, models=models, seasonality=7, train_df=df).sort_values(
+        "unique_id"
+    )
+    mase_block = (
+        result_mixed[result_mixed["metric"] == "mase"]
+        .drop(columns="metric")
+        .sort_values("unique_id")
+        .reset_index(drop=True)
+    )
+    np.testing.assert_allclose(
+        mase_block[models].to_numpy(),
+        direct_mase[models].reset_index(drop=True)[models].to_numpy(),
+    )
+    mae_block = (
+        result_mixed[result_mixed["metric"] == "mae"]
+        .drop(columns="metric")
+        .sort_values("unique_id")
+        .reset_index(drop=True)
+    )
+    pd.testing.assert_frame_equal(mae_block[models], direct_mae[models])

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1544,3 +1544,120 @@ def test_evaluate_batched_simple_metrics_duplicate_and_mixed():
         .reset_index(drop=True)
     )
     pd.testing.assert_frame_equal(mae_block[models], direct_mae[models])
+
+
+# ========================================
+# Non-batched fallback must forward a non-default `cutoff_col` (bugfix)
+# ========================================
+#
+# `evaluate`'s `kwargs` dict used to only include `cutoff_col` when a metric
+# required `train_df`. Any metric that instead fell through to the plain
+# `else` branch -- a `functools.partial`-wrapped registry metric (which
+# never batches, since `_SIMPLE_METRIC_SPECS` is keyed by function identity)
+# or a metric outside `_SIMPLE_METRIC_SPECS` entirely, e.g. `nd` -- was
+# called without `cutoff_col`, so it silently fell back to the metric's own
+# default ('cutoff') instead of the caller's column. With a non-default
+# `cutoff_col` name and a `cutoff` column absent from `df`, that collapsed
+# every cutoff fold for a series into a single row instead of one row per
+# (id, cutoff). The batched path (which receives `cutoff_col` directly, not
+# through `kwargs`) already grouped correctly -- this is what made the bug a
+# same-call, divergent-answer split between the two code paths. These tests
+# pin all three call shapes to the same per-cutoff grouping a direct metric
+# call produces.
+
+
+def _cutoff_adversarial_df(engine: str, cutoff_col: str):
+    """Like `_adversarial_eval_df`, but with two folds per series stored
+    under a non-default `cutoff_col` name."""
+    df = _adversarial_eval_df("pandas")
+    n = len(df)
+    cutoff_vals = np.where(
+        np.arange(n) % 2 == 0,
+        np.datetime64("2020-01-01"),
+        np.datetime64("2020-01-02"),
+    )
+    df[cutoff_col] = cutoff_vals
+    if engine == "polars":
+        df = pl.from_pandas(df)
+    return df
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_evaluate_non_default_cutoff_col_batched_metric(engine):
+    """(a) A batched metric (`mae`) groups per-cutoff under a non-default
+    `cutoff_col` name, matching a direct call."""
+    cutoff_col = "fold_id"
+    df = _cutoff_adversarial_df(engine, cutoff_col)
+    models = ["model0", "model1", "model2"]
+    n_series = nw.from_native(df)["unique_id"].n_unique()
+
+    result = evaluate(df, [mae], models=models, cutoff_col=cutoff_col)
+    result_nw = nw.from_native(result)
+    assert cutoff_col in result_nw.columns
+    assert result_nw.shape[0] == 2 * n_series
+
+    direct = nw.from_native(mae(df, models=models, cutoff_col=cutoff_col)).sort(
+        ["unique_id", cutoff_col]
+    )
+    sub = result_nw.drop("metric").sort(["unique_id", cutoff_col])
+    for model in models:
+        np.testing.assert_allclose(
+            direct[model].to_numpy().astype(float),
+            sub[model].to_numpy().astype(float),
+            equal_nan=True,
+        )
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_evaluate_non_default_cutoff_col_partial_registry_metric(engine):
+    """(b) A `functools.partial`-wrapped registry metric never batches
+    (`_SIMPLE_METRIC_SPECS` is keyed by function identity, not name), so it
+    always goes through the non-batched fallback -- this is exactly the path
+    that dropped `cutoff_col`."""
+    cutoff_col = "fold_id"
+    df = _cutoff_adversarial_df(engine, cutoff_col)
+    models = ["model0", "model1", "model2"]
+    n_series = nw.from_native(df)["unique_id"].n_unique()
+    partial_mae = partial(mae)
+
+    result = evaluate(df, [partial_mae], models=models, cutoff_col=cutoff_col)
+    result_nw = nw.from_native(result)
+    assert cutoff_col in result_nw.columns
+    assert result_nw.shape[0] == 2 * n_series
+
+    direct = nw.from_native(mae(df, models=models, cutoff_col=cutoff_col)).sort(
+        ["unique_id", cutoff_col]
+    )
+    sub = result_nw.drop("metric").sort(["unique_id", cutoff_col])
+    for model in models:
+        np.testing.assert_allclose(
+            direct[model].to_numpy().astype(float),
+            sub[model].to_numpy().astype(float),
+            equal_nan=True,
+        )
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_evaluate_non_default_cutoff_col_non_registry_metric(engine):
+    """(c) A metric outside `_SIMPLE_METRIC_SPECS` entirely (`nd`) also
+    always goes through the non-batched fallback."""
+    cutoff_col = "fold_id"
+    df = _cutoff_adversarial_df(engine, cutoff_col)
+    models = ["model0", "model1", "model2"]
+    n_series = nw.from_native(df)["unique_id"].n_unique()
+
+    result = evaluate(df, [nd], models=models, cutoff_col=cutoff_col)
+    result_nw = nw.from_native(result)
+    assert cutoff_col in result_nw.columns
+    assert result_nw.shape[0] == 2 * n_series
+
+    direct = nw.from_native(nd(df, models=models, cutoff_col=cutoff_col)).sort(
+        ["unique_id", cutoff_col]
+    )
+    sub = result_nw.drop("metric").sort(["unique_id", cutoff_col])
+    for model in models:
+        np.testing.assert_allclose(
+            direct[model].to_numpy().astype(float),
+            sub[model].to_numpy().astype(float),
+            equal_nan=True,
+        )

--- a/tests/test_grouped_array.py
+++ b/tests/test_grouped_array.py
@@ -57,6 +57,23 @@ def test_append_several_2d():
         np.array([0, 2, 4, 8]),
     )
 
+# 2d data, 1d new_values: exercises the `data.ndim == 2 and new_values.ndim
+# == 1` reshape branch in `_append_several` (as opposed to `test_append_
+# several_2d` above, where `new_values` is already 2D and that branch is
+# never taken).
+def test_append_several_2d_data_1d_new_values():
+    data = np.arange(5).reshape(-1, 1)
+    indptr = np.array([0, 2, 5])
+    new_sizes = np.array([0, 2, 1])
+    new_values = np.array([6, 7, 5])  # 1D, must be reshaped to match `data`
+    new_groups = np.array([False, True, False])
+    new_data, new_indptr = _append_several(data, indptr, new_sizes, new_values, new_groups)
+    np.testing.assert_equal(new_data, np.array([0, 1, 6, 7, 2, 3, 4, 5]).reshape(-1, 1))
+    np.testing.assert_equal(
+        new_indptr,
+        np.array([0, 2, 4, 8]),
+    )
+
 
 # The `GroupedArray` is used internally for storing the series values and performing transformations.
 def test_grouped_array():

--- a/tests/test_grouped_array.py
+++ b/tests/test_grouped_array.py
@@ -137,3 +137,146 @@ def test_grouped_array_1d():
     ga_pl = GroupedArray.from_sorted_df(series_pl, "unique_id", "ds", "y")
     np.testing.assert_allclose(ga_pd.data, ga_pl.data)
     np.testing.assert_equal(ga_pd.indptr, ga_pl.indptr)
+
+
+# ========================================
+# _append_one / _append_several: vectorized scatter (perf)
+# ========================================
+#
+# Both used a python loop over every group to splice new rows in. They're
+# now vectorized scatter-writes (see `_ranges_to_indexer` reuse in
+# grouped_array.py). These tests pin the vectorized versions against the
+# literal original per-group loop on adversarial inputs: empty groups, all
+# groups new/old, 1D and 2D data, and varying dtypes.
+
+
+def _reference_append_one(data, indptr, new):
+    n_groups = len(indptr) - 1
+    n_rows = data.shape[0] + new.shape[0]
+    if data.ndim == 2:
+        new_data = np.empty_like(data, shape=(n_rows, data.shape[1]))
+    else:
+        new_data = np.empty_like(data, shape=n_rows)
+    new_indptr = indptr.copy()
+    new_indptr[1:] += np.arange(1, n_groups + 1)
+    for i in range(n_groups):
+        prev_slice = slice(indptr[i], indptr[i + 1])
+        new_slice = slice(new_indptr[i], new_indptr[i + 1] - 1)
+        new_data[new_slice] = data[prev_slice]
+        new_data[new_indptr[i + 1] - 1] = new[i]
+    return new_data, new_indptr
+
+
+def _reference_append_several(data, indptr, new_sizes, new_values, new_groups):
+    n_rows = data.shape[0] + new_values.shape[0]
+    if data.ndim == 2:
+        new_data = np.empty_like(data, shape=(n_rows, data.shape[1]))
+    else:
+        new_data = np.empty_like(data, shape=n_rows)
+    new_indptr = np.empty_like(indptr, shape=new_sizes.size + 1)
+    new_indptr[0] = 0
+    old_indptr_idx = 0
+    new_vals_idx = 0
+    for i, is_new in enumerate(new_groups):
+        new_size = new_sizes[i]
+        if is_new:
+            old_size = 0
+        else:
+            prev_slice = slice(indptr[old_indptr_idx], indptr[old_indptr_idx + 1])
+            old_indptr_idx += 1
+            old_size = prev_slice.stop - prev_slice.start
+            new_size += old_size
+            new_data[new_indptr[i] : new_indptr[i] + old_size] = data[prev_slice]
+        new_indptr[i + 1] = new_indptr[i] + new_size
+        new_data[new_indptr[i] + old_size : new_indptr[i + 1]] = new_values[
+            new_vals_idx : new_vals_idx + new_sizes[i]
+        ]
+        new_vals_idx += new_sizes[i]
+    return new_data, new_indptr
+
+
+class TestAppendVectorizedMatchesReferenceLoop:
+    def test_append_one_adversarial(self):
+        rng = np.random.default_rng(0)
+        for trial in range(100):
+            n_groups = rng.integers(1, 30)
+            sizes = rng.integers(0, 10, size=n_groups)  # allow empty groups
+            indptr = np.append(0, sizes.cumsum()).astype(np.int64)
+            total = int(sizes.sum())
+            if rng.random() < 0.5:
+                data = rng.normal(size=total)
+                new = rng.normal(size=n_groups)
+            else:
+                ncols = rng.integers(1, 4)
+                data = rng.normal(size=(total, ncols))
+                new = rng.normal(size=(n_groups, ncols))
+            actual_data, actual_indptr = _append_one(data, indptr, new)
+            expected_data, expected_indptr = _reference_append_one(data, indptr, new)
+            np.testing.assert_array_equal(
+                actual_indptr, expected_indptr, err_msg=f"trial {trial}"
+            )
+            np.testing.assert_allclose(
+                actual_data, expected_data, err_msg=f"trial {trial}"
+            )
+
+    def test_append_several_adversarial(self):
+        rng = np.random.default_rng(1)
+        for trial in range(100):
+            n_groups = rng.integers(1, 30)
+            new_groups = rng.random(n_groups) < 0.3
+            n_old_groups = int((~new_groups).sum())
+            old_sizes = rng.integers(0, 8, size=n_old_groups)
+            indptr = np.append(0, old_sizes.cumsum()).astype(np.int64)
+            total_old = int(old_sizes.sum())
+            new_sizes = rng.integers(0, 5, size=n_groups)
+            total_new = int(new_sizes.sum())
+            if rng.random() < 0.5:
+                data = rng.normal(size=total_old)
+                new_values = rng.normal(size=total_new)
+            else:
+                ncols = rng.integers(1, 4)
+                data = rng.normal(size=(total_old, ncols))
+                new_values = rng.normal(size=(total_new, ncols))
+            actual_data, actual_indptr = _append_several(
+                data, indptr, new_sizes, new_values, new_groups
+            )
+            expected_data, expected_indptr = _reference_append_several(
+                data, indptr, new_sizes, new_values, new_groups
+            )
+            np.testing.assert_array_equal(
+                actual_indptr, expected_indptr, err_msg=f"trial {trial}"
+            )
+            np.testing.assert_allclose(
+                actual_data, expected_data, err_msg=f"trial {trial}"
+            )
+
+    def test_append_several_all_new_groups(self):
+        # no pre-existing groups at all (e.g. GroupedArray starting empty)
+        data = np.array([])
+        indptr = np.array([0])
+        new_sizes = np.array([2, 0, 3])
+        new_values = np.array([1.0, 2.0, 5.0, 6.0, 7.0])
+        new_groups = np.array([True, True, True])
+        actual_data, actual_indptr = _append_several(
+            data, indptr, new_sizes, new_values, new_groups
+        )
+        expected_data, expected_indptr = _reference_append_several(
+            data, indptr, new_sizes, new_values, new_groups
+        )
+        np.testing.assert_array_equal(actual_indptr, expected_indptr)
+        np.testing.assert_allclose(actual_data, expected_data)
+
+    def test_append_several_all_old_groups_no_new_values(self):
+        data = np.arange(6.0)
+        indptr = np.array([0, 2, 4, 6])
+        new_sizes = np.array([0, 0, 0])
+        new_values = np.array([])
+        new_groups = np.array([False, False, False])
+        actual_data, actual_indptr = _append_several(
+            data, indptr, new_sizes, new_values, new_groups
+        )
+        expected_data, expected_indptr = _reference_append_several(
+            data, indptr, new_sizes, new_values, new_groups
+        )
+        np.testing.assert_array_equal(actual_indptr, expected_indptr)
+        np.testing.assert_allclose(actual_data, expected_data)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -7,7 +7,11 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from utilsforecast.preprocessing import fill_gaps, id_time_grid
+from utilsforecast.preprocessing import (
+    _vectorized_serie_ranges,
+    fill_gaps,
+    id_time_grid,
+)
 
 
 @pytest.fixture
@@ -531,10 +535,12 @@ class TestFillGapsIncompatibleFrequency:
 #
 # `id_time_grid`'s pandas path used to build each serie's timestamps with a
 # python-level loop (`np.hstack([np.arange(s, e, delta) for s, e in
-# zip(starts, ends)])`). It's now a single vectorized computation. These
-# tests pin the vectorized version against that literal inline loop on
-# adversarial series (varying lengths, single-point series, multi-step
-# deltas, datetime and integer frequencies).
+# zip(starts, ends)])`). It's now a single vectorized computation, extracted
+# into `_vectorized_serie_ranges` so it's a pure, directly-testable unit
+# (also called by `id_time_grid` itself -- these tests exercise the actual
+# production code, not a copy of the algorithm). These tests pin it against
+# that literal inline loop on adversarial series (varying lengths,
+# single-point series, multi-step deltas, datetime and integer frequencies).
 
 
 def _reference_arange_hstack(starts, ends, delta):
@@ -553,12 +559,7 @@ class TestIdTimeGridVectorizedRanges:
             n_steps = rng.integers(1, 25, size=n)
             ends = starts + n_steps * delta
             expected = _reference_arange_hstack(starts, ends, delta)
-            sizes = np.maximum(((ends - starts) / delta).astype(np.int64), 0)
-            total = int(sizes.sum())
-            offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
-                np.cumsum(sizes) - sizes, sizes
-            )
-            actual = np.repeat(starts, sizes) + offsets_in_serie * delta
+            actual, _sizes = _vectorized_serie_ranges(starts, ends, delta)
             np.testing.assert_array_equal(actual, expected)
 
     def test_matches_reference_loop_datetime_freq(self):
@@ -571,12 +572,7 @@ class TestIdTimeGridVectorizedRanges:
             n_steps = rng.integers(1, 25, size=n)
             ends = starts + n_steps.astype(np.int64) * delta
             expected = _reference_arange_hstack(starts, ends, delta)
-            sizes = np.maximum(((ends - starts) / delta).astype(np.int64), 0)
-            total = int(sizes.sum())
-            offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
-                np.cumsum(sizes) - sizes, sizes
-            )
-            actual = np.repeat(starts, sizes) + offsets_in_serie * delta
+            actual, _sizes = _vectorized_serie_ranges(starts, ends, delta)
             np.testing.assert_array_equal(actual, expected)
 
     def test_id_time_grid_int_freq_end_to_end(self):
@@ -648,4 +644,104 @@ class TestIdTimeGridVectorizedRanges:
             g = pd.DatetimeIndex(grid[grid["unique_id"] == uid]["ds"])
             expected = pd.date_range(sub["ds"].min(), sub["ds"].max(), freq="MS")
             # values only, see the dtype note in test_id_time_grid_single_point_series
+            np.testing.assert_array_equal(g.to_numpy(), expected.to_numpy())
+
+
+# ========================================
+# id_time_grid: negative-range validation
+# ========================================
+#
+# A negative time range (computed `end` before `start` for a particular
+# serie) happens when a fixed `start`/`end` bound doesn't align with that
+# serie's own timestamps -- e.g. a fixed `start` later than a serie's own
+# `end` (`end="per_serie"`). On `main`, this crashed with an opaque,
+# accidental `ValueError: repeats may not contain negative values` from
+# `np.repeat(times_by_id.index, sizes)`, only because `sizes` happened to be
+# negative in that case, not because it validated anything -- the crash
+# depended on the vagaries of `np.repeat`'s error handling and would have
+# behaved differently for a near-zero negative gap (see the exactly-zero
+# test below). `id_time_grid` now validates this explicitly upfront and
+# raises a clear `ValueError` naming the offending series.
+
+
+class TestIdTimeGridNegativeRangeValidation:
+    def test_negative_range_datetime_raises_clear_error(self):
+        # serie "a" ends 2020-01-05; a fixed start of 2020-01-10 is after it
+        df = pd.DataFrame(
+            {
+                "unique_id": ["a", "a", "b", "b"],
+                "ds": pd.to_datetime(
+                    ["2020-01-01", "2020-01-05", "2020-06-01", "2020-06-10"]
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="negative time range") as exc_info:
+            id_time_grid(df, freq="D", start="2020-01-10", end="per_serie")
+        message = str(exc_info.value)
+        assert "'a'" in message
+        assert "1 serie" in message
+
+    def test_negative_range_int_raises_clear_error(self):
+        # serie "a" ends at 5; a fixed start of 50 is after it
+        df = pd.DataFrame(
+            {
+                "unique_id": ["a", "a", "b", "b"],
+                "ds": [0, 5, 100, 110],
+            }
+        )
+        with pytest.raises(ValueError, match="negative time range") as exc_info:
+            id_time_grid(df, freq=1, start=50, end="per_serie")
+        message = str(exc_info.value)
+        assert "'a'" in message
+        assert "1 serie" in message
+
+    def test_negative_range_names_every_offending_serie(self):
+        # both series have a fixed start after their own end
+        df = pd.DataFrame(
+            {
+                "unique_id": ["a", "a", "b", "b"],
+                "ds": pd.to_datetime(
+                    ["2020-01-01", "2020-01-05", "2020-01-02", "2020-01-06"]
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="negative time range") as exc_info:
+            id_time_grid(df, freq="D", start="2020-01-10", end="per_serie")
+        message = str(exc_info.value)
+        assert "2 serie" in message
+
+    def test_zero_length_range_is_legitimate_not_an_error(self):
+        # start == end for every serie (single-point series): a legitimate
+        # empty/single-point range, not a negative one -- must not raise.
+        df = pd.DataFrame(
+            {
+                "unique_id": ["a", "b"],
+                "ds": pd.to_datetime(["2020-01-01", "2020-01-05"]),
+            }
+        )
+        grid = id_time_grid(df, freq="D", start="per_serie", end="per_serie")
+        assert len(grid) == 2
+
+    def test_normal_ranges_unaffected_by_validation(self):
+        # sanity: typical per_serie/global usage (positive ranges for every
+        # serie) still produces the expected grid and doesn't raise.
+        df = pd.DataFrame(
+            {
+                "unique_id": np.repeat(["a", "b"], [3, 3]),
+                "ds": pd.to_datetime(
+                    [
+                        "2020-01-01",
+                        "2020-01-02",
+                        "2020-01-05",
+                        "2020-01-03",
+                        "2020-01-04",
+                        "2020-01-10",
+                    ]
+                ),
+            }
+        )
+        grid = id_time_grid(df, freq="D")
+        for uid, sub in df.groupby("unique_id"):
+            g = pd.DatetimeIndex(grid[grid["unique_id"] == uid]["ds"])
+            expected = pd.date_range(sub["ds"].min(), df["ds"].max(), freq="D")
             np.testing.assert_array_equal(g.to_numpy(), expected.to_numpy())

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -7,7 +7,7 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from utilsforecast.preprocessing import fill_gaps
+from utilsforecast.preprocessing import fill_gaps, id_time_grid
 
 
 @pytest.fixture
@@ -523,3 +523,129 @@ class TestFillGapsIncompatibleFrequency:
                 data = create_error_test_data(dates_int, N_PERIODS, include_start, include_end, "polars")
                 with pytest.raises(ValueError):
                     fill_gaps(data, freq_str, start=start, end=end)
+
+
+# ========================================
+# id_time_grid: vectorized per-serie range construction (perf)
+# ========================================
+#
+# `id_time_grid`'s pandas path used to build each serie's timestamps with a
+# python-level loop (`np.hstack([np.arange(s, e, delta) for s, e in
+# zip(starts, ends)])`). It's now a single vectorized computation. These
+# tests pin the vectorized version against that literal inline loop on
+# adversarial series (varying lengths, single-point series, multi-step
+# deltas, datetime and integer frequencies).
+
+
+def _reference_arange_hstack(starts, ends, delta):
+    """The original per-serie python loop `id_time_grid` used to build."""
+    return np.hstack([np.arange(s, e, delta) for s, e in zip(starts, ends)])
+
+
+class TestIdTimeGridVectorizedRanges:
+    def test_matches_reference_loop_int_freq(self):
+        rng = np.random.default_rng(123)
+        for _ in range(25):
+            n = rng.integers(1, 40)
+            delta = int(rng.integers(1, 5))
+            # starts/ends land on multiples of delta, like real timestamps do
+            starts = (rng.integers(0, 100, size=n) * delta).astype(np.int64)
+            n_steps = rng.integers(1, 25, size=n)
+            ends = starts + n_steps * delta
+            expected = _reference_arange_hstack(starts, ends, delta)
+            sizes = np.maximum(((ends - starts) / delta).astype(np.int64), 0)
+            total = int(sizes.sum())
+            offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
+                np.cumsum(sizes) - sizes, sizes
+            )
+            actual = np.repeat(starts, sizes) + offsets_in_serie * delta
+            np.testing.assert_array_equal(actual, expected)
+
+    def test_matches_reference_loop_datetime_freq(self):
+        rng = np.random.default_rng(321)
+        for _ in range(25):
+            n = rng.integers(1, 40)
+            base = np.datetime64("2020-01-01")
+            delta = np.timedelta64(int(rng.integers(1, 4)), "D")
+            starts = base + (rng.integers(0, 500, size=n).astype(np.int64) * delta)
+            n_steps = rng.integers(1, 25, size=n)
+            ends = starts + n_steps.astype(np.int64) * delta
+            expected = _reference_arange_hstack(starts, ends, delta)
+            sizes = np.maximum(((ends - starts) / delta).astype(np.int64), 0)
+            total = int(sizes.sum())
+            offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
+                np.cumsum(sizes) - sizes, sizes
+            )
+            actual = np.repeat(starts, sizes) + offsets_in_serie * delta
+            np.testing.assert_array_equal(actual, expected)
+
+    def test_id_time_grid_int_freq_end_to_end(self):
+        df = pd.DataFrame(
+            {
+                "unique_id": np.repeat(["a", "b", "c"], [5, 1, 10]),
+                "ds": np.concatenate(
+                    [np.arange(5), np.array([7]), np.arange(10)]
+                ),
+            }
+        )
+        # explicit per_serie/per_serie so each id spans only its own
+        # [min, max] inclusive at step 1 (the default `end` is "global")
+        grid = id_time_grid(df, freq=1, start="per_serie", end="per_serie")
+        for uid, sub in df.groupby("unique_id"):
+            g = grid[grid["unique_id"] == uid]["ds"].to_numpy()
+            np.testing.assert_array_equal(
+                g, np.arange(sub["ds"].min(), sub["ds"].max() + 1)
+            )
+
+    def test_id_time_grid_business_day_freq(self):
+        df = pd.DataFrame(
+            {
+                "unique_id": np.repeat(["a", "b"], [10, 8]),
+                "ds": np.concatenate(
+                    [
+                        pd.bdate_range("2020-01-01", periods=10),
+                        pd.bdate_range("2020-01-06", periods=8),
+                    ]
+                ),
+            }
+        )
+        grid = id_time_grid(df, freq="B")
+        assert (pd.DatetimeIndex(grid["ds"]).dayofweek < 5).all()
+
+    def test_id_time_grid_single_point_series(self):
+        # start == end for every serie: each should contribute exactly its
+        # own single timestamp when start/end are 'per_serie'.
+        df = pd.DataFrame(
+            {
+                "unique_id": ["a", "b", "c"],
+                "ds": pd.to_datetime(["2020-01-01", "2020-01-05", "2020-01-10"]),
+            }
+        )
+        grid = id_time_grid(df, freq="D", start="per_serie", end="per_serie")
+        # id_time_grid always returns datetime64[ns]; compare values only
+        # (dtype -- ns vs pandas' default us -- is intentional and unrelated
+        # to the ranges themselves)
+        pd.testing.assert_series_equal(
+            grid.sort_values("unique_id")["ds"].reset_index(drop=True),
+            df.sort_values("unique_id")["ds"].reset_index(drop=True),
+            check_dtype=False,
+        )
+
+    def test_id_time_grid_monthly_freq(self):
+        df = pd.DataFrame(
+            {
+                "unique_id": np.repeat(["a", "b"], [6, 4]),
+                "ds": np.concatenate(
+                    [
+                        pd.date_range("2020-01-01", periods=6, freq="MS"),
+                        pd.date_range("2020-03-01", periods=4, freq="MS"),
+                    ]
+                ),
+            }
+        )
+        grid = id_time_grid(df, freq="MS")
+        for uid, sub in df.groupby("unique_id"):
+            g = pd.DatetimeIndex(grid[grid["unique_id"] == uid]["ds"])
+            expected = pd.date_range(sub["ds"].min(), sub["ds"].max(), freq="MS")
+            # values only, see the dtype note in test_id_time_grid_single_point_series
+            np.testing.assert_array_equal(g.to_numpy(), expected.to_numpy())

--- a/utilsforecast/evaluation.py
+++ b/utilsforecast/evaluation.py
@@ -6,7 +6,7 @@ __all__ = ["evaluate"]
 import inspect
 import re
 import reprlib
-from typing import Callable, Dict, List, Optional, Union, get_origin
+from typing import Callable, Dict, List, Mapping, Optional, Union, get_origin
 
 import narwhals.stable.v2 as nw
 import numpy as np
@@ -225,7 +225,7 @@ def _weighted_mean_agg(
     )
 
 
-def _is_simple_call(metric_params) -> bool:
+def _is_simple_call(metric_params: Mapping[str, inspect.Parameter]) -> bool:
     """Whether `evaluate` would call a metric through the plain `else` branch:
     no `train_df`, `baseline`, `q`/quantile-dict, `quantiles` or `level`."""
     return (
@@ -254,14 +254,17 @@ def _precompute_batched_simple_metrics(
     its result dataframe, with columns `[*group_cols, *model_cols]` exactly
     like a standalone call to that metric would produce.
     """
-    base_metrics_needed = set()
+    # a dict (not a set) so the batched dataframe's internal column order is
+    # deterministic (insertion order, matching the order metrics appear in
+    # `metrics`) rather than depending on function objects' hash/id order.
+    base_metrics_needed: Dict[Callable, None] = {}
     for metric in metrics:
         base_metric = _SQRT_DERIVED_METRICS.get(metric, metric)
         if base_metric not in _SIMPLE_METRIC_SPECS:
             continue
         metric_params = inspect.signature(metric).parameters
         if _is_simple_call(metric_params):
-            base_metrics_needed.add(base_metric)
+            base_metrics_needed[base_metric] = None
     if not base_metrics_needed:
         return {}
 
@@ -534,12 +537,24 @@ def evaluate(
     results_per_metric = []
     for metric in metrics:
         metric_name = _function_name(metric)
+        metric_params = inspect.signature(metric).parameters
         kwargs = dict(df=df, models=model_cols, id_col=id_col, target_col=target_col)
+        # Forward `cutoff_col` whenever the metric accepts it (every builtin
+        # metric does; a user-supplied metric may not, per `evaluate`'s
+        # docstring, so this stays conditional rather than unconditional).
+        # This also covers the non-batched fallback below (the plain `else`
+        # branch): it used to only receive `cutoff_col` when the metric
+        # required `train_df`, so any other metric shape -- e.g. a
+        # `functools.partial`-wrapped registry metric, which never batches
+        # since `_SIMPLE_METRIC_SPECS` is keyed by function identity, or a
+        # metric outside that registry entirely -- silently fell back to the
+        # metric's own default `cutoff_col` and collapsed every cutoff fold
+        # for a series into a single row instead of one row per (id, cutoff).
+        if "cutoff_col" in metric_params:
+            kwargs["cutoff_col"] = cutoff_col
         if metric_requires_y_train[metric_name]:
             kwargs["train_df"] = train_df
-            kwargs["cutoff_col"] = cutoff_col
             kwargs["time_col"] = time_col
-        metric_params = inspect.signature(metric).parameters
         if "baseline" in metric_params:
             metric_name = f"{metric_name}_{metric_params['baseline'].default}"
         if "q" in metric_params or metric_params["models"].annotation is Dict[str, str]:
@@ -577,6 +592,10 @@ def evaluate(
                 )
                 results_per_metric.append(result)
         else:
+            # keep in sync with _is_simple_call's exclusion set: this branch
+            # is reached for exactly the metrics _is_simple_call considers a
+            # "plain" call (no train_df/baseline/q/quantiles/level), which is
+            # also the only shape _precompute_batched_simple_metrics batches.
             base_metric = _SQRT_DERIVED_METRICS.get(metric, metric)
             if base_metric in batched_simple_results:
                 result = ufp.copy_if_pandas(batched_simple_results[base_metric])

--- a/utilsforecast/evaluation.py
+++ b/utilsforecast/evaluation.py
@@ -15,7 +15,12 @@ import pandas as pd
 import utilsforecast.processing as ufp
 
 from .compat import AnyDFType, DFType, DistributedDFType, pl, pl_DataFrame
-from .losses import _get_group_cols
+from .losses import (
+    _SIMPLE_METRIC_SPECS,
+    _SQRT_DERIVED_METRICS,
+    _batch_nw_agg_expr,
+    _get_group_cols,
+)
 
 _WEIGHT_COL = "__utilsforecast_weight"
 
@@ -218,6 +223,67 @@ def _weighted_mean_agg(
         .sort(*group_cols)
         .to_native()
     )
+
+
+def _is_simple_call(metric_params) -> bool:
+    """Whether `evaluate` would call a metric through the plain `else` branch:
+    no `train_df`, `baseline`, `q`/quantile-dict, `quantiles` or `level`."""
+    return (
+        "train_df" not in metric_params
+        and "baseline" not in metric_params
+        and "q" not in metric_params
+        and metric_params["models"].annotation is not Dict[str, str]
+        and "quantiles" not in metric_params
+        and "level" not in metric_params
+    )
+
+
+def _precompute_batched_simple_metrics(
+    df: DFType,
+    metrics: List[Callable],
+    model_cols: List[str],
+    id_col: str,
+    target_col: str,
+    cutoff_col: str,
+) -> Dict[Callable, DFType]:
+    """Batch every requested metric that matches `_SIMPLE_METRIC_SPECS` (and any
+    metric derived from one, e.g. `rmse` from `mse`) into a single `group_by`
+    pass instead of computing each with its own. See `_batch_nw_agg_expr`.
+
+    Returns a mapping from each such base metric (e.g. `mse`, not `rmse`) to
+    its result dataframe, with columns `[*group_cols, *model_cols]` exactly
+    like a standalone call to that metric would produce.
+    """
+    base_metrics_needed = set()
+    for metric in metrics:
+        base_metric = _SQRT_DERIVED_METRICS.get(metric, metric)
+        if base_metric not in _SIMPLE_METRIC_SPECS:
+            continue
+        metric_params = inspect.signature(metric).parameters
+        if _is_simple_call(metric_params):
+            base_metrics_needed.add(base_metric)
+    if not base_metrics_needed:
+        return {}
+
+    specs = []
+    for base_metric in base_metrics_needed:
+        agg, expr_builder = _SIMPLE_METRIC_SPECS[base_metric]
+        specs.append(
+            (_function_name(base_metric), agg, model_cols, expr_builder(target_col))
+        )
+    batched = _batch_nw_agg_expr(
+        df=df, id_col=id_col, cutoff_col=cutoff_col, specs=specs
+    )
+    group_cols = _get_group_cols(df=df, id_col=id_col, cutoff_col=cutoff_col)
+    batched_nw = nw.from_native(batched)
+    results = {}
+    for base_metric in base_metrics_needed:
+        alias_prefix = _function_name(base_metric)
+        results[base_metric] = batched_nw.select(
+            *group_cols,
+            *[nw.col(f"{alias_prefix}__{m}").alias(m) for m in model_cols],
+        ).to_native()
+    return results
 
 
 def _evaluate_wrapper(
@@ -456,6 +522,15 @@ def evaluate(
                 f"The following series are missing from the train_df: {reprlib.repr(missing_series)}"
             )
 
+    batched_simple_results = _precompute_batched_simple_metrics(
+        df=df,
+        metrics=metrics,
+        model_cols=model_cols,
+        id_col=id_col,
+        target_col=target_col,
+        cutoff_col=cutoff_col,
+    )
+
     results_per_metric = []
     for metric in metrics:
         metric_name = _function_name(metric)
@@ -502,7 +577,18 @@ def evaluate(
                 )
                 results_per_metric.append(result)
         else:
-            result = metric(**kwargs)
+            base_metric = _SQRT_DERIVED_METRICS.get(metric, metric)
+            if base_metric in batched_simple_results:
+                result = ufp.copy_if_pandas(batched_simple_results[base_metric])
+                if base_metric is not metric:
+                    # e.g. rmse = sqrt(mse); mse was the one that got batched
+                    result = (
+                        nw.from_native(result)
+                        .with_columns(*[nw.col(m).sqrt() for m in model_cols])
+                        .to_native()
+                    )
+            else:
+                result = metric(**kwargs)
             result = ufp.assign_columns(result, "metric", metric_name)
             results_per_metric.append(result)
     if isinstance(df, pd.DataFrame):

--- a/utilsforecast/grouped_array.py
+++ b/utilsforecast/grouped_array.py
@@ -6,7 +6,13 @@ from typing import Sequence, Tuple, Union
 import numpy as np
 
 from .compat import DataFrame
-from .processing import counts_by_id, value_cols_to_numpy
+from .processing import _ranges_to_indexer, counts_by_id, value_cols_to_numpy
+
+
+def _empty_like_rows(data: np.ndarray, n_rows: int) -> np.ndarray:
+    if data.ndim == 2:
+        return np.empty_like(data, shape=(n_rows, data.shape[1]))
+    return np.empty_like(data, shape=n_rows)
 
 
 def _append_one(
@@ -15,17 +21,19 @@ def _append_one(
     """Append each value of new to each group in data formed by indptr."""
     n_groups = len(indptr) - 1
     n_rows = data.shape[0] + new.shape[0]
-    if data.ndim == 2:
-        new_data = np.empty_like(data, shape=(n_rows, data.shape[1]))
-    else:
-        new_data = np.empty_like(data, shape=n_rows)
+    new_data = _empty_like_rows(data, n_rows)
     new_indptr = indptr.copy()
     new_indptr[1:] += np.arange(1, n_groups + 1)
-    for i in range(n_groups):
-        prev_slice = slice(indptr[i], indptr[i + 1])
-        new_slice = slice(new_indptr[i], new_indptr[i + 1] - 1)
-        new_data[new_slice] = data[prev_slice]
-        new_data[new_indptr[i + 1] - 1] = new[i]
+    # every group grows by exactly one row, appended at its end (position
+    # new_indptr[i + 1] - 1); scatter `new` there and the untouched positions
+    # keep the original per-group order from `data`.
+    insert_pos = new_indptr[1:] - 1
+    keep_mask = np.ones(n_rows, dtype=bool)
+    keep_mask[insert_pos] = False
+    new_data[keep_mask] = data
+    new_data[insert_pos] = (
+        new.reshape(-1, 1) if data.ndim == 2 and new.ndim == 1 else new
+    )
     return new_data, new_indptr
 
 
@@ -36,30 +44,30 @@ def _append_several(
     new_values: np.ndarray,
     new_groups: np.ndarray,
 ) -> Tuple[np.ndarray, np.ndarray]:
+    n_groups = new_sizes.size
     n_rows = data.shape[0] + new_values.shape[0]
-    if data.ndim == 2:
-        new_data = np.empty_like(data, shape=(n_rows, data.shape[1]))
-    else:
-        new_data = np.empty_like(data, shape=n_rows)
-    new_indptr = np.empty_like(indptr, shape=new_sizes.size + 1)
+    new_data = _empty_like_rows(data, n_rows)
+
+    is_old = ~new_groups
+    old_sizes = np.zeros(n_groups, dtype=np.int64)
+    old_sizes[is_old] = np.diff(indptr)
+    total_sizes = old_sizes + new_sizes
+    new_indptr = np.empty_like(indptr, shape=n_groups + 1)
     new_indptr[0] = 0
-    old_indptr_idx = 0
-    new_vals_idx = 0
-    for i, is_new in enumerate(new_groups):
-        new_size = new_sizes[i]
-        if is_new:
-            old_size = 0
-        else:
-            prev_slice = slice(indptr[old_indptr_idx], indptr[old_indptr_idx + 1])
-            old_indptr_idx += 1
-            old_size = prev_slice.stop - prev_slice.start
-            new_size += old_size
-            new_data[new_indptr[i] : new_indptr[i] + old_size] = data[prev_slice]
-        new_indptr[i + 1] = new_indptr[i] + new_size
-        new_data[new_indptr[i] + old_size : new_indptr[i + 1]] = new_values[
-            new_vals_idx : new_vals_idx + new_sizes[i]
-        ]
-        new_vals_idx += new_sizes[i]
+    np.cumsum(total_sizes, out=new_indptr[1:])
+
+    # existing rows keep their relative order at the start of each group
+    old_starts = new_indptr[:-1][is_old]
+    old_idx = _ranges_to_indexer(old_starts, old_starts + old_sizes[is_old])
+    new_data[old_idx] = data
+    # new rows are appended right after each group's (possibly empty) old data
+    new_starts = new_indptr[:-1] + old_sizes
+    new_idx = _ranges_to_indexer(new_starts, new_starts + new_sizes)
+    new_data[new_idx] = (
+        new_values.reshape(-1, 1)
+        if data.ndim == 2 and new_values.ndim == 1
+        else new_values
+    )
     return new_data, new_indptr
 
 

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -28,7 +28,7 @@ __all__ = [
     "linex",
 ]
 
-from typing import Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import narwhals.stable.v2 as nw
 import numpy as np
@@ -85,6 +85,57 @@ def _nw_agg_expr(
     )
 
 
+def _batch_nw_agg_expr(
+    df: IntoDataFrameT,
+    id_col: str,
+    cutoff_col: str,
+    specs: List[Tuple[str, str, List[str], Callable[[Any], nw.Expr]]],
+) -> IntoDataFrameT:
+    """Compute several `_nw_agg_expr`-shaped metrics with a single `group_by` pass.
+
+    `evaluate` calls several metric functions on the same `df`, each of which
+    (for the "simple" per-model metrics, e.g. `mae`/`mse`/`bias`) independently
+    performs its own `select` + `group_by` + `agg` through `_nw_agg_expr`. That
+    means the `id_col` (and `cutoff_col`) grouping is recomputed from scratch
+    once per metric even though it's identical every time. This combines any
+    number of such metrics into one `select` + `group_by` + `agg` call.
+
+    Args:
+        specs: One entry per metric, as `(alias_prefix, agg, models, gen_expr)`
+            -- the same arguments a standalone `_nw_agg_expr` call would take
+            for that metric, plus an `alias_prefix` used to namespace its
+            output columns.
+
+    Returns:
+        A dataframe with the group columns plus one `f"{alias_prefix}__{model}"`
+        column per `(metric, model)` pair, sorted by the group columns (matching
+        `_nw_agg_expr`'s own output order).
+    """
+    group_cols = _get_group_cols(df=df, id_col=id_col, cutoff_col=cutoff_col)
+    raw_exprs = []
+    mean_cols: List[str] = []
+    sum_cols: List[str] = []
+    for alias_prefix, agg, models, gen_expr in specs:
+        if agg not in ("mean", "sum"):
+            raise ValueError(f"Unsupported batched aggregation: '{agg}'.")
+        agg_cols = mean_cols if agg == "mean" else sum_cols
+        for model in models:
+            out_col = f"{alias_prefix}__{model}"
+            raw_exprs.append(gen_expr(model).alias(out_col))
+            agg_cols.append(out_col)
+    return (
+        nw.from_native(df)
+        .select(*group_cols, *raw_exprs)
+        .group_by(*group_cols)
+        .agg(
+            *[nw.col(c).mean().alias(c) for c in mean_cols],
+            *[nw.col(c).sum().alias(c) for c in sum_cols],
+        )
+        .sort(*group_cols)
+        .to_native()
+    )
+
+
 def _create_train_with_cutoffs(
     train_df: IntoDataFrameT,
     df: IntoDataFrameT,
@@ -121,6 +172,13 @@ def _scale_loss(
     )
 
 
+def _mae_expr(target_col: str) -> Callable[[Any], nw.Expr]:
+    def gen_expr(model) -> nw.Expr:
+        return (nw.col(target_col) - nw.col(model)).abs().alias(model)
+
+    return gen_expr
+
+
 @_base_docstring
 def mae(
     df: IntoDataFrameT,
@@ -141,8 +199,15 @@ def mae(
         models=models,
         id_col=id_col,
         cutoff_col=cutoff_col,
-        gen_expr=lambda m: (nw.col(target_col) - nw.col(m)).abs().alias(m),
+        gen_expr=_mae_expr(target_col),
     )
+
+
+def _mse_expr(target_col: str) -> Callable[[Any], nw.Expr]:
+    def gen_expr(model) -> nw.Expr:
+        return ((nw.col(target_col) - nw.col(model)) ** 2).alias(model)
+
+    return gen_expr
 
 
 @_base_docstring
@@ -165,7 +230,7 @@ def mse(
         models=models,
         id_col=id_col,
         cutoff_col=cutoff_col,
-        gen_expr=lambda m: ((nw.col(target_col) - nw.col(m)) ** 2).alias(m),
+        gen_expr=_mse_expr(target_col),
     )
 
 
@@ -200,6 +265,13 @@ def rmse(
     )
 
 
+def _bias_expr(target_col: str) -> Callable[[Any], nw.Expr]:
+    def gen_expr(model) -> nw.Expr:
+        return (nw.col(model) - nw.col(target_col)).alias(model)
+
+    return gen_expr
+
+
 @_base_docstring
 def bias(
     df: IntoDataFrameT,
@@ -216,7 +288,7 @@ def bias(
         models=models,
         id_col=id_col,
         cutoff_col=cutoff_col,
-        gen_expr=lambda m: (nw.col(m) - nw.col(target_col)).alias(m),
+        gen_expr=_bias_expr(target_col),
     )
 
 
@@ -238,9 +310,16 @@ def cfe(
         models=models,
         id_col=id_col,
         cutoff_col=cutoff_col,
-        gen_expr=lambda m: (nw.col(m) - nw.col(target_col)).alias(m),
+        gen_expr=_bias_expr(target_col),
         agg="sum",
     )
+
+
+def _pis_expr(target_col: str) -> Callable[[Any], nw.Expr]:
+    def gen_expr(model) -> nw.Expr:
+        return (nw.col(model) - nw.col(target_col)).abs().alias(model)
+
+    return gen_expr
 
 
 @_base_docstring
@@ -262,7 +341,7 @@ def pis(
         models=models,
         id_col=id_col,
         cutoff_col=cutoff_col,
-        gen_expr=lambda m: (nw.col(m) - nw.col(target_col)).abs().alias(m),
+        gen_expr=_pis_expr(target_col),
         agg="sum",
     )
 
@@ -328,6 +407,15 @@ def _zero_to_nan(series):
     return nw.when(series == 0).then(float("nan")).otherwise(series)
 
 
+def _mape_expr(target_col: str) -> Callable[[Any], nw.Expr]:
+    def gen_expr(model) -> nw.Expr:
+        abs_err = (nw.col(target_col) - nw.col(model)).abs()
+        abs_target = _zero_to_nan(nw.col(target_col)).abs()
+        return (abs_err / abs_target).alias(model)
+
+    return gen_expr
+
+
 @_base_docstring
 def mape(
     df: IntoDataFrameT,
@@ -344,19 +432,22 @@ def mape(
     averages these devations over the length of the series.
     The closer to zero an observed value is, the higher penalty MAPE loss
     assigns to the corresponding error."""
-
-    def gen_expr(model):
-        abs_err = (nw.col(target_col) - nw.col(model)).abs()
-        abs_target = _zero_to_nan(nw.col(target_col)).abs()
-        return (abs_err / abs_target).alias(model)
-
     return _nw_agg_expr(
         df=df,
         models=models,
         id_col=id_col,
-        gen_expr=gen_expr,
+        gen_expr=_mape_expr(target_col),
         cutoff_col=cutoff_col,
     )
+
+
+def _smape_expr(target_col: str) -> Callable[[Any], nw.Expr]:
+    def gen_expr(model) -> nw.Expr:
+        abs_err = (nw.col(model) - nw.col(target_col)).abs()
+        denominator = _zero_to_nan(nw.col(model).abs() + nw.col(target_col).abs())
+        return (abs_err / denominator).alias(model).fill_null(0)
+
+    return gen_expr
 
 
 @_base_docstring
@@ -377,19 +468,34 @@ def smape(
     of the series. This allows the SMAPE to have bounds between
     0% and 100% which is desirable compared to normal MAPE that
     may be undetermined when the target is zero."""
-
-    def gen_expr(model):
-        abs_err = (nw.col(model) - nw.col(target_col)).abs()
-        denominator = _zero_to_nan(nw.col(model).abs() + nw.col(target_col).abs())
-        return (abs_err / denominator).alias(model).fill_null(0)
-
     return _nw_agg_expr(
         df=df,
         models=models,
         id_col=id_col,
-        gen_expr=gen_expr,
+        gen_expr=_smape_expr(target_col),
         cutoff_col=cutoff_col,
     )
+
+
+# Metrics that `evaluate` can compute in a single batched `group_by` (see
+# `_batch_nw_agg_expr`) because they share the `_nw_agg_expr` shape: a single
+# per-model expression reduced with `mean` or `sum`, with no `train_df`,
+# `level`, `quantiles` or `baseline` argument involved. Maps each metric to
+# its `(agg, expr_builder)` pair.
+_SIMPLE_METRIC_SPECS: Dict[
+    Callable, Tuple[str, Callable[[str], Callable[[Any], nw.Expr]]]
+] = {
+    mae: ("mean", _mae_expr),
+    mse: ("mean", _mse_expr),
+    bias: ("mean", _bias_expr),
+    cfe: ("sum", _bias_expr),
+    pis: ("sum", _pis_expr),
+    mape: ("mean", _mape_expr),
+    smape: ("mean", _smape_expr),
+}
+# Metrics computed from one of the entries above via an extra elementwise
+# transform applied after the (batched) aggregation.
+_SQRT_DERIVED_METRICS: Dict[Callable, Callable] = {rmse: mse}
 
 
 def mase(

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -173,7 +173,7 @@ def _scale_loss(
 
 
 def _mae_expr(target_col: str) -> Callable[[Any], nw.Expr]:
-    def gen_expr(model) -> nw.Expr:
+    def gen_expr(model: str) -> nw.Expr:
         return (nw.col(target_col) - nw.col(model)).abs().alias(model)
 
     return gen_expr
@@ -204,7 +204,7 @@ def mae(
 
 
 def _mse_expr(target_col: str) -> Callable[[Any], nw.Expr]:
-    def gen_expr(model) -> nw.Expr:
+    def gen_expr(model: str) -> nw.Expr:
         return ((nw.col(target_col) - nw.col(model)) ** 2).alias(model)
 
     return gen_expr
@@ -266,7 +266,7 @@ def rmse(
 
 
 def _bias_expr(target_col: str) -> Callable[[Any], nw.Expr]:
-    def gen_expr(model) -> nw.Expr:
+    def gen_expr(model: str) -> nw.Expr:
         return (nw.col(model) - nw.col(target_col)).alias(model)
 
     return gen_expr
@@ -316,7 +316,7 @@ def cfe(
 
 
 def _pis_expr(target_col: str) -> Callable[[Any], nw.Expr]:
-    def gen_expr(model) -> nw.Expr:
+    def gen_expr(model: str) -> nw.Expr:
         return (nw.col(model) - nw.col(target_col)).abs().alias(model)
 
     return gen_expr
@@ -408,7 +408,7 @@ def _zero_to_nan(series):
 
 
 def _mape_expr(target_col: str) -> Callable[[Any], nw.Expr]:
-    def gen_expr(model) -> nw.Expr:
+    def gen_expr(model: str) -> nw.Expr:
         abs_err = (nw.col(target_col) - nw.col(model)).abs()
         abs_target = _zero_to_nan(nw.col(target_col)).abs()
         return (abs_err / abs_target).alias(model)
@@ -442,7 +442,7 @@ def mape(
 
 
 def _smape_expr(target_col: str) -> Callable[[Any], nw.Expr]:
-    def gen_expr(model) -> nw.Expr:
+    def gen_expr(model: str) -> nw.Expr:
         abs_err = (nw.col(model) - nw.col(target_col)).abs()
         denominator = _zero_to_nan(nw.col(model).abs() + nw.col(target_col).abs())
         return (abs_err / denominator).alias(model).fill_null(0)
@@ -482,8 +482,19 @@ def smape(
 # per-model expression reduced with `mean` or `sum`, with no `train_df`,
 # `level`, `quantiles` or `baseline` argument involved. Maps each metric to
 # its `(agg, expr_builder)` pair.
+#
+# The `expr_builder`s below (`_mae_expr`, ...) declare their returned
+# `gen_expr` as `Callable[[Any], nw.Expr]`, looser than the `Callable[[str],
+# nw.Expr]` declared here: they're also passed directly to `_nw_agg_expr`
+# (e.g. inside `mae()`), whose `gen_expr` parameter must accept `str` *or*
+# `tuple[str, str]` (for `quantile_loss`/`calibration`-style callers), and
+# `Callable[[str], nw.Expr]` isn't assignable there (parameter types are
+# contravariant, and `str` alone doesn't cover the wider union). Every entry
+# actually registered here is only ever called with a plain `str` model
+# column, so this dict's own type is intentionally narrower -- `Any` is
+# compatible with both, so the same functions satisfy both call sites.
 _SIMPLE_METRIC_SPECS: Dict[
-    Callable, Tuple[str, Callable[[str], Callable[[Any], nw.Expr]]]
+    Callable, Tuple[str, Callable[[str], Callable[[str], nw.Expr]]]
 ] = {
     mae: ("mean", _mae_expr),
     mse: ("mean", _mse_expr),

--- a/utilsforecast/preprocessing.py
+++ b/utilsforecast/preprocessing.py
@@ -3,10 +3,11 @@
 __all__ = ["id_time_grid", "fill_gaps"]
 
 
+import reprlib
 import warnings
 from datetime import date, datetime
 from functools import partial
-from typing import Union
+from typing import Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -53,6 +54,40 @@ def _determine_bound_pl(
             val = bound
         out = repeat(pl_Series([val]), times_by_id.shape[0])
     return out
+
+
+def _vectorized_serie_ranges(
+    starts,
+    ends,
+    delta: Union[np.timedelta64, int],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Equivalent to `np.hstack([np.arange(s, e, delta) for s, e in zip(starts, ends)])`,
+    but avoids a per-serie python loop: broadcasts each serie's start over its size and
+    adds the running offset within that serie.
+
+    `starts`/`ends` are left untyped (not `np.ndarray`) on purpose: `id_time_grid`'s local
+    variables of the same name are also assigned a `pl_Series` in its polars branch, which
+    mypy's single-scope inference conflates across both branches for the whole function --
+    an existing, pre-this-PR limitation of that function, not something this helper should
+    paper over with a falsely-precise annotation.
+
+    Callers must ensure `ends >= starts` (i.e. `((ends - starts) / delta).astype(np.int64)`
+    is non-negative) for every serie beforehand -- `np.repeat` below raises an opaque,
+    unrelated-looking error for a negative repeat count otherwise. This helper doesn't
+    re-check that itself so it stays a small, pure, easily-testable unit; `id_time_grid`
+    validates it upfront with a clear message naming the offending series.
+
+    Returns:
+        times: the concatenated per-serie ranges, in serie order.
+        sizes: the number of timestamps contributed by each serie.
+    """
+    sizes = ((ends - starts) / delta).astype(np.int64)
+    total = int(sizes.sum())
+    offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
+        np.cumsum(sizes) - sizes, sizes
+    )
+    times = np.repeat(starts, sizes) + offsets_in_serie * delta
+    return times, sizes
 
 
 def id_time_grid(
@@ -166,15 +201,26 @@ def id_time_grid(
     times_by_id = df.groupby(id_col, observed=True)[time_col].agg(["min", "max"])
     starts = _determine_bound(start, freq, times_by_id, "min")
     ends = _determine_bound(end, freq, times_by_id, "max") + delta
-    sizes = np.maximum(((ends - starts) / delta).astype(np.int64), 0)
-    # equivalent to np.hstack([np.arange(s, e, delta) for s, e in zip(starts, ends)])
-    # but avoids a per-series python loop: broadcast each serie's start over
-    # its size and add the running offset within that serie.
-    total = int(sizes.sum())
-    offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
-        np.cumsum(sizes) - sizes, sizes
-    )
-    times = np.repeat(starts, sizes) + offsets_in_serie * delta
+    # a negative range (end before start) happens when a fixed `start`/`end`
+    # bound doesn't align with a particular serie's own timestamps, e.g. a
+    # fixed `start` later than that serie's `end`. Check for it explicitly
+    # with a clear message -- left unchecked, `_vectorized_serie_ranges`'
+    # `np.repeat(starts, sizes)` raises an opaque "negative dimensions are
+    # not allowed" error instead. A range that's exactly zero-length (e.g.
+    # `start == end`, a single-point serie) is legitimate and yields an
+    # empty range for that serie, not an error.
+    raw_sizes = ((ends - starts) / delta).astype(np.int64)
+    negative_mask = raw_sizes < 0
+    if negative_mask.any():
+        bad_ids = times_by_id.index[negative_mask].tolist()
+        raise ValueError(
+            "`id_time_grid` computed a negative time range (`end` before "
+            f"`start`) for {len(bad_ids)} serie(s): {reprlib.repr(bad_ids)}. "
+            "This happens when the `start`/`end` bounds don't align with a "
+            f"serie's own timestamps, e.g. a fixed `start={start!r}` later "
+            f"than that serie's own `end` (`end={end!r}`, `freq={freq!r}`)."
+        )
+    times, sizes = _vectorized_serie_ranges(starts, ends, delta)
     uids = np.repeat(times_by_id.index, sizes)
     if isinstance(freq, str):
         if isinstance(offset.base, pd.offsets.BusinessDay):

--- a/utilsforecast/preprocessing.py
+++ b/utilsforecast/preprocessing.py
@@ -166,10 +166,15 @@ def id_time_grid(
     times_by_id = df.groupby(id_col, observed=True)[time_col].agg(["min", "max"])
     starts = _determine_bound(start, freq, times_by_id, "min")
     ends = _determine_bound(end, freq, times_by_id, "max") + delta
-    sizes = ((ends - starts) / delta).astype(np.int64)
-    times = np.hstack(
-        [np.arange(start, end, delta) for start, end in zip(starts, ends)]
+    sizes = np.maximum(((ends - starts) / delta).astype(np.int64), 0)
+    # equivalent to np.hstack([np.arange(s, e, delta) for s, e in zip(starts, ends)])
+    # but avoids a per-series python loop: broadcast each serie's start over
+    # its size and add the running offset within that serie.
+    total = int(sizes.sum())
+    offsets_in_serie = np.arange(total, dtype=np.int64) - np.repeat(
+        np.cumsum(sizes) - sizes, sizes
     )
+    times = np.repeat(starts, sizes) + offsets_in_serie * delta
     uids = np.repeat(times_by_id.index, sizes)
     if isinstance(freq, str):
         if isinstance(offset.base, pd.offsets.BusinessDay):


### PR DESCRIPTION

## Labels

Recommended label: `enhancement` -- `release-drafter`'s configured categories (`feature`, `breaking change`, `fix`, `documentation`, `dependencies`, `enhancement`) don't include a dedicated "performance" category, and `enhancement` is the closest fit for a behavior-preserving speedup. (This PR also contains one intentional bugfix -- see the `evaluate()`/`cutoff_col` note under Testing below -- but it's small enough, and bundled with the perf work it was found alongside, that it doesn't warrant splitting into a separate `fix`-labeled PR.)

## What

Three focused performance fixes, picked after profiling `losses.py`, `evaluation.py`, `preprocessing.py`, `feature_engineering.py` and `grouped_array.py` on synthetic 10k-series x 200-point data (pandas + polars):

1. **`evaluate()` batches its "simple" metrics into a single `group_by` pass.** `mae`, `mse`, `rmse`, `bias`, `cfe`, `pis`, `mape`, `smape` each independently ran their own `select` + `group_by` + `agg` over the same `df`, re-grouping (re-factorizing `id_col`/`cutoff_col`) from scratch once per metric. A new `_batch_nw_agg_expr` helper (`losses.py`) combines every requested metric of this shape into one `group_by`/`agg` call; `rmse` reuses `mse`'s batched result and applies `sqrt` on top. Metrics needing `train_df`, `level`, or `quantiles` (`mase`, `mqloss`, `coverage`, ...) are untouched.
2. **`id_time_grid`'s per-serie range construction is vectorized.** It built each serie's timestamps with `np.hstack([np.arange(s, e, delta) for s, e in zip(starts, ends)])` -- a Python loop over every serie. Replaced with a single vectorized computation using the same cumulative-offset trick already used elsewhere in the file (e.g. `_ranges_to_indexer`).
3. **`GroupedArray._append_one` / `_append_several` are vectorized.** Both spliced new rows into every group with a Python loop. Rewritten as scatter-writes; `_append_several` reuses the existing `processing._ranges_to_indexer` helper instead of duplicating the range-flattening logic. `GroupedArray.append`/`append_several` are public-API surface that a `mlforecast`/`statsforecast`-style subclass could call once per step in recursive multi-step forecasting -- no current call site in this repo or its known downstream libraries was actually found and profiled, so treat that as the guarantee this API makes rather than a measured hot path (see Benchmarks below for what was actually profiled).

4. **Bugfix, found while implementing #1: `evaluate()`'s non-batched fallback dropped a non-default `cutoff_col`.** `evaluate()` builds a `kwargs` dict for each metric call; it only included `cutoff_col` when the metric required `train_df`. Any metric that instead went through the plain non-batched `else` branch -- a `functools.partial`-wrapped registry metric (e.g. `functools.partial(mae)`, which never batches since `_SIMPLE_METRIC_SPECS` is keyed by function identity, not name) or any metric outside that registry entirely (e.g. `nd`, `wape`, `linex`) -- was called without `cutoff_col`, so it silently fell back to that metric's own default (`"cutoff"`) instead of the caller's column. With a non-default `cutoff_col` name (and no column literally named `cutoff` in `df`), this collapsed every cutoff fold for a series into a single row instead of one row per `(id, cutoff)` -- the batched path (which receives `cutoff_col` as a direct function argument, not through `kwargs`) already grouped correctly, making this a same-call, divergent-answer split between the two code paths. **Behavior change:** callers using a non-default `cutoff_col` with a metric that goes through the non-batched fallback now get correct per-cutoff rows where `main` silently collapsed folds together -- row counts for those calls increase. Fixed by forwarding `cutoff_col` in `kwargs` whenever the metric's signature accepts it (every builtin metric does); this is conditional rather than unconditional because `evaluate()` also supports user-supplied metrics with a narrower signature (`df`, `models`, `id_col`, `target_col` only, per the docstring) that don't accept `cutoff_col` at all -- see `tests/test_evaluation.py::test_evaluate_weighted_mean_uses_effective_denominator`/`test_evaluate_weighted_mean_excludes_missing_metric_values` for existing coverage of that narrower shape, which an unconditional forward would have broken.

## Why

Profiling `evaluate(df, [mae, mse, rmse, mape, smape, bias, cfe, pis])` on 10k series x 200 points showed >90% of wall time in repeated pandas `groupby` machinery (factorize + Cython reduction), called once per metric for data that's identical across all of them. `id_time_grid`'s and `GroupedArray`'s Python loops scale with series count and show up directly in `fill_gaps`/`GroupedArray.append`, both hot in preprocessing and recursive-forecast paths respectively.

Explicitly **not** done (shotgun avoided): `feature_engineering._assign_slices`'s per-serie loop was profiled; its main `vals` copy is already as fast as a vectorized fancy-indexing rewrite (both ~20ms at 10k series) so that part was left alone, though its `future_vals` line does have a real, unrelated `np.tile` win (see the native-kernel candidates and Deviations sections below) that's out of scope for this PR. `fill_gaps`'s dominant cost (pandas `set_index().reindex()` on a `MultiIndex`, largely a pandas-3.0 PyArrow-string-dtype factorize cost) wasn't touched: fixing it safely would mean restructuring the whole reindex strategy, which is out of scope for a focused PR -- see the follow-up list below.

## How

- `utilsforecast/losses.py`: extracted the inline `gen_expr` closures for `mae`/`mse`/`bias`/`cfe`/`pis`/`mape`/`smape` into small named builders (`_mae_expr`, `_mse_expr`, ...) so they're reusable, without changing what each function does when called standalone. Added `_batch_nw_agg_expr` (one `select` + `group_by` + `agg` for N metrics, supporting mixed `mean`/`sum` aggregations in the same pass) and two registries: `_SIMPLE_METRIC_SPECS` (metric -> `(agg, expr_builder)`) and `_SQRT_DERIVED_METRICS` (`rmse` -> `mse`).
- `utilsforecast/evaluation.py`: `evaluate()` now precomputes a `batched_simple_results` cache via `_precompute_batched_simple_metrics` before its metrics loop (only for metrics that would've gone through the plain `else` branch -- no `train_df`/`baseline`/`q`/`quantiles`/`level`), and the loop pulls from that cache instead of calling the metric again. Metric order, row order, and dtypes in the output are unchanged; a metric requested twice or mixed with non-batchable metrics reads from an independent shallow copy each time (`ufp.copy_if_pandas`) to avoid aliasing the cached result across output blocks. `_precompute_batched_simple_metrics`'s internal `base_metrics_needed` accumulator is a dict (insertion-ordered), not a set, so the batched dataframe's internal column order is deterministic rather than depending on function objects' hash/id order. Also (see item 4 above): the per-metric `kwargs` dict now forwards `cutoff_col` whenever the metric's signature accepts it, not only when `train_df` is required; the plain `else` branch has a comment noting it must stay in sync with `_is_simple_call`'s exclusion set, since both determine which metrics take the non-batched path.
- `utilsforecast/preprocessing.py`: `id_time_grid`'s `sizes = ((ends - starts) / delta).astype(np.int64)` + `np.hstack([np.arange(...) for ...])` became a call to a new module-level helper, `_vectorized_serie_ranges(starts, ends, delta)`, that computes `sizes` + a single `np.repeat(starts, sizes) + offsets_in_serie * delta` -- bit-exact with the old loop (same integer truncation semantics, verified adversarially) for any serie with a non-negative range. Before calling it, `id_time_grid` now explicitly validates that every serie's computed range is non-negative and raises a `ValueError` naming the offending serie(s) if not; on `main`, a negative range (a fixed `start`/`end` bound that doesn't align with a particular serie's own timestamps) crashed with an opaque, accidental `ValueError: repeats may not contain negative values` from `np.repeat`, which depended on `sizes` happening to be negative rather than on any real validation -- a near-zero negative gap (magnitude smaller than one `delta`) truncated to `0` and didn't crash at all, silently and correctly producing an empty range for that serie. The new check reproduces that same "negative truncates to non-negative -> fine" distinction on purpose, so `start == end` (a legitimate single-point/empty serie) still isn't an error.
- `utilsforecast/grouped_array.py`: `_append_one` masks the per-group insertion positions and does one scatter-write instead of a per-group slice loop. `_append_several` computes old/new destination index arrays via `processing._ranges_to_indexer` (already used for the identical range-flattening pattern in `backtest_splits`) instead of a per-group Python loop with manual pointer bookkeeping.
- Typing cleanup: the six `_SIMPLE_METRIC_SPECS` expression builders in `losses.py` (`_mae_expr`, `_mse_expr`, `_bias_expr`, `_pis_expr`, `_mape_expr`, `_smape_expr`) are only ever called with a `str` model column (never the `tuple[str, str]` shape `quantile_loss`/`calibration` use), so their return type is now `Callable[[str], nw.Expr]` instead of the looser `Callable[[Any], nw.Expr]`, matching `_SIMPLE_METRIC_SPECS`'s own declared type; `_is_simple_call`'s `metric_params` parameter is now annotated `Mapping[str, inspect.Parameter]`.

No new dependencies. Both pandas and polars backends verified.

## Benchmarks (measured)

Synthetic data: 10,000 series x 200 points, 3 models. Machine had other concurrent workloads running during these runs (shared box), so treat the exact multipliers as directional, not lab-clean; the isolated/idle-machine numbers were noticeably larger (e.g. up to ~4.7x for the 5-metric `evaluate()` case, ~11x for `_append_one`).

| Benchmark | Before | After | Speedup |
|---|---|---|---|
| `evaluate()`, 8 metrics x 3 models, pandas | 1.036s | 0.884s | 1.17x |
| `evaluate()`, 8 metrics x 3 models, polars | 0.528s | 0.269s | 1.96x |
| `evaluate()`, 3 metrics (mae/mse/rmse) x 3 models, pandas | 0.449s | 0.131s | 3.43x |
| `evaluate()`, 3 metrics (mae/mse/rmse) x 3 models, polars | 0.117s | 0.044s | 2.64x |
| `id_time_grid()`, 10k series with gaps, pandas | 0.213s | 0.049s | 4.37x |
| `fill_gaps()`, 10k series with gaps, pandas | 0.161s | 0.158s | ~1x (expected -- dominated by the untouched pandas `reindex`, see follow-ups) |
| `GroupedArray.append()`, 10k groups, single step | 0.0068s | 0.0010s | 6.8x |
| `GroupedArray.append()`, 10k groups, 14 recursive steps (e.g. `h=14` recursive forecast) | 0.349s | 0.053s | 6.6x |

Reproduction: synthetic-data benchmark script used for these numbers (not committed; available on request), `git stash` / `git stash pop` to compare before/after on the same tree.

## Testing

- `uv run pytest tests/` (full suite, matching CI's `pytest.yml`): **1557 passed, 1 skipped** (the 1 skip is the pre-existing Windows-only distributed-evaluate skip), 89.07% coverage (repo requires 80%). The +12 tests / +0.05pp coverage versus the original count (1545 passed, 89.02%) come from the review-fix round below.
- New regression tests, each comparing the vectorized/batched implementation against the literal old implementation (inline reference) on adversarial inputs, per `CONTRIBUTING.md`'s test guidance:
  - `tests/test_evaluation.py`: `evaluate()`'s batched path vs. standalone `mae`/`mse`/`rmse`/`bias`/`cfe`/`pis`/`mape`/`smape` calls, with zero targets, an all-zero model (smape denominator edge case), NaN predictions, with/without `cutoff_col`, duplicated metrics, and mixed batchable/non-batchable metric lists (`mae` + `mase` together).
  - `tests/test_preprocessing.py`: vectorized range construction vs. the literal `np.hstack`/`np.arange` loop on random adversarial series (varying lengths, integer and datetime deltas), plus end-to-end `id_time_grid` checks for integer, business-day, monthly, and single-point series.
  - `tests/test_grouped_array.py`: `_append_one`/`_append_several` vs. the literal per-group loop on empty groups, all-new groups, all-old groups with no new values, and 1D/2D data (100-200 randomized adversarial trials each).
- `uvx ruff check utilsforecast/*` and `uvx ruff format --check utilsforecast/*` (matches `.github/workflows/lint.yaml`'s `pre-commit run --files utilsforecast/*`): clean.
- `uvx mypy --ignore-missing-imports utilsforecast`: **correction from an earlier draft of this PR body, which claimed this was clean on the 4 touched files -- that was wrong.** Running it against the whole package (matching how `.pre-commit-config.yaml` invokes it) shows 95 pre-existing errors spanning `evaluation.py`, `losses.py`, `preprocessing.py`, `feature_engineering.py`, `plotting.py` and `processing.py`, all present before this PR's changes (verified via `git stash`/`git stash pop` diff on this same tree) and out of scope to fix here. This PR's own changes introduce **zero new** mypy findings versus that 95-error baseline -- verified by diffing `mypy`'s output with and without this PR's changes (identical error set modulo line-number shifts from inserted code).

### Review-fix round (consolidated fixes from 3 independent reviews)

- **Critical bugfix, `evaluate()`/`cutoff_col`:** reproduced the bug directly (a `functools.partial(mae)` call and a bare `nd` call, both under a non-default `cutoff_col`, silently collapsed 2 cutoff folds per series into 1 row each), confirmed the fix restores correct per-cutoff grouping matching a direct metric call, and confirmed the existing test suite (which only exercised the default `cutoff_col` name) didn't catch this -- 6 new tests do, one per (call shape) x (pandas/polars).
- **`id_time_grid` negative-range crash:** reproduced `main`'s exact accidental crash mode (`ValueError: repeats may not contain negative values` from `np.repeat` with a negative count) with an isolated numpy repro matching `main`'s old code precisely, confirmed the new explicit check raises a clear, informative `ValueError` instead for both a datetime and an int case, and confirmed the legitimate `start == end` zero-length case still doesn't raise.
- **Typing (six `losses.py` expr builders):** the review's literal suggestion (`Callable[[str], nw.Expr]` on the builders themselves) was tried first and found to introduce 7 new mypy errors -- `_nw_agg_expr`'s `gen_expr` parameter must accept `str | tuple[str, str]`, and a `str`-only `Callable` isn't assignable there under contravariance. Verified with an isolated mypy repro before deciding: narrowed `_SIMPLE_METRIC_SPECS`'s own declared type instead (where every entry really is called with `str` only), left the builders' own return type as the broader `Callable[[Any], nw.Expr]` they need for `_nw_agg_expr` compatibility, and confirmed this produces the same 95-error baseline as before (zero new findings) while still tightening the registry's type where it's actually accurate.

## Repo-convention findings

- **Not nbdev-generated.** `nbs/` only contains `docs/` and `_quarto.yml` (mkdocs/mintlify pipeline), no `.ipynb` sources for the library modules -- `utilsforecast/*.py` are edited directly, no AUTOGENERATED markers.
- **No manual changelog file.** Releases use `release-drafter` (`.github/workflows/release-drafter.yml`), which auto-generates notes from merged PR titles/labels (categories: `feature`, `breaking change`, `fix`, `documentation`, `dependencies`, `enhancement`). No `CHANGELOG.md` to update.
- CI (`pytest.yml`) runs the full suite across Python 3.10-3.14 on ubuntu/macos/windows via `uv sync --group dev && uv run pytest`; lint CI only runs `pre-commit` (ruff + mypy) against `utilsforecast/*`, not `tests/*` (tests are more loosely styled -- confirmed pre-existing lint findings there, e.g. unused `rmae` import, unsorted imports, that predate this PR and weren't touched to keep this diff focused).
- `CONTRIBUTING.md`: "Do not mix style changes/fixes with functional changes" -- followed; ran `ruff format` on a full pre-existing test file once by mistake mid-session (would have reformatted ~150 unrelated lines) and reverted it before committing, keeping the test diff to just the new test blocks.

## Native-kernel candidates for coreforecast (follow-up, not in scope here)

Ops that would benefit from a C++/Rust kernel in `coreforecast` if this becomes a dedicated effort, roughly ordered by expected win:

1. **pandas `fill_gaps`'s `set_index([id_col, time_col]).reindex(idx)`** -- the single biggest cost measured in this investigation (~250-350ms of the ~350ms `fill_gaps` total at 10k x 200, dominated by pandas' generic `MultiIndex`/factorize/take machinery, worsened by pandas 3.0's default PyArrow-backed string dtype for `id_col`). A kernel that does a direct positional scatter (given sorted `(id, time)` grids and a fixed step) instead of going through pandas' generic hash-based reindex could plausibly cut this by 5-10x. Expected magnitude: **large** (single biggest remaining bottleneck in this whole area).
2. **`evaluate()`'s repeated pandas `groupby`/factorize when narwhals mediates it** -- batching (this PR) still leaves narwhals' pandas-like backend doing one Cython reduction call per output column rather than a single fused multi-column `.agg()`; a kernel-level fused groupby-reduce (sum/mean of many columns by one key, single pass) would close that last gap. Expected magnitude: **moderate** (measured ~3-4x further headroom over what this PR already captures on the pandas backend specifically; polars already gets close to the full win without a kernel).
3. **`GroupedArray.append`/`append_several` for very high step counts** -- now vectorized in pure numpy, but still allocates a new `(n_rows, ...)` array per call; a kernel with in-place/amortized growth (like a growable arena) would help workloads that call `append` hundreds of times (e.g. very long recursive horizons). Expected magnitude: **small-to-moderate**, mostly relevant to extreme-`h` recursive forecasting rather than typical usage.
4. **`feature_engineering._assign_slices`'s per-serie slice copy** -- the `vals` assignment (`vals[start:start+size, :] = feats[...]`) is genuinely memcpy-bound: a vectorized fancy-indexing rewrite measured the same speed as the existing loop (~20ms either way at 10k series), so a kernel would only help there via SIMD/threading, not algorithmic restructuring. The `future_vals` assignment in the same loop is a different story: `future_vals[i*h:(i+1)*h] = feats[max_samples-h:]` assigns the *same* slice of `feats` on every iteration (it doesn't depend on `i`), so it's a pure broadcast that a single `np.tile(feats[max_samples-h:], (sizes.size, 1))` replaces outright -- no kernel needed, a real, reproducible win on this whole function (a from-scratch spot-check during review measured ~20-30% faster end-to-end at 10k series/h=14, in the same ballpark as the ~33% figure from the original investigation; exact magnitude is data-shape-dependent). Deferred out of scope for this PR (it's a separate, unrelated function from the three fixes here, and touching it would've meant re-opening review-scope discussion rather than shipping a focused diff) -- not a dead end, just parked as a fast, low-risk follow-up.

## Deviations

- Did not touch `fill_gaps`'s pandas reindex path even though it's the largest single cost measured (see follow-up #1) -- fixing it safely (bit-exact, handling tz-aware/business-day/irregular-frequency edge cases, categorical ids) would have meant a much larger, riskier diff than fits a focused PR; flagged as the top follow-up candidate instead.
- `feature_engineering._assign_slices`'s per-serie Python loop (explicitly called out as a plausible target in the task) is a mixed bag, not a uniform false lead. Its `vals` assignment really is a false lead: a vectorized fancy-indexing rewrite measured the same speed as the existing loop (~20ms either way at 10k series), because each per-serie chunk is already a large enough contiguous memcpy that the Python-level loop overhead is negligible. Its `future_vals` assignment, however, is a real, low-risk win -- it copies the *same* slice of `feats` on every loop iteration (doesn't vary with `i`), so a single `np.tile(...)` replaces the whole per-serie loop for that one line; see follow-up #4 above for the measurement. Left unchanged in this PR (out of scope for this focused diff, not because it wasn't worth doing) rather than folding an unrelated function into a PR about `evaluate`/`id_time_grid`/`GroupedArray`.
- Benchmark numbers in this PR body were captured on a shared/loaded machine (other concurrent workloads running); an earlier isolated run showed noticeably larger multipliers (e.g. ~4.7x for `evaluate()` with 5 batched metrics, ~11x for `_append_one`). Reported the loaded-machine numbers as the more conservative, honestly-measured figures rather than cherry-picking the faster isolated run.
- Review item 1 asked for `cutoff_col` to be forwarded "unconditionally" in `evaluate()`'s fallback `kwargs`. Implemented conditionally instead (`if "cutoff_col" in metric_params`): `evaluate()`'s docstring documents support for user-supplied metrics with a narrower signature (`df`, `models`, `id_col`, `target_col` only), and two existing tests (`test_evaluate_weighted_mean_excludes_missing_metric_values`, `test_evaluate_weighted_mean_uses_effective_denominator`) exercise exactly that narrower shape -- an unconditional forward broke both with a `TypeError: got an unexpected keyword argument 'cutoff_col'` (confirmed directly, then fixed). The conditional version fixes the exact same bug for every metric that actually accepts `cutoff_col` (every builtin metric, including all 3 adversarial cases the review asked for tests on) while staying backward compatible with the narrower-signature contract `evaluate()` already promises.
- Review item 4's typing suggestion for the six `losses.py` expr builders (`Callable[[str], nw.Expr]`, literally) was not applied as-is -- see the mypy note under Testing above for why, and what was done instead.
