### PR TITLE
fix: correct Tweedie deviance formula for power not in {0, 1}

### DIFF
--- a/docs/losses.html.md
+++ b/docs/losses.html.md
@@ -436,7 +436,7 @@ d_{p}(y,\mu)
 y\,\ln\!\frac{y}{\mu}\;-\;(y-\mu),
 & p = 1\quad(\text{Poisson deviance}),\\[0.5em]
 \displaystyle
--2\Bigl[\ln\!\frac{y}{\mu}\;-\;\frac{y-\mu}{\mu}\Bigr],
+-\Bigl[\ln\!\frac{y}{\mu}\;-\;\frac{y-\mu}{\mu}\Bigr],
 & p = 2\quad(\text{Gamma deviance}).
 \end{cases}
 ```

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -176,7 +176,7 @@ def tweedie_deviance_single(y_true, y_pred, power, **kwargs):
     elif power == 1:
         return np.mean(2 * (y_true * np.log(y_true / y_pred) - (y_true - y_pred)))
     elif power == 2:
-        return np.mean(2 * (np.log(y_pred) - np.log(y_true)) + y_true / y_pred - 1)
+        return np.mean(2 * ((np.log(y_pred) - np.log(y_true)) + y_true / y_pred - 1))
     else:
         return np.mean(
             2
@@ -234,6 +234,14 @@ def linex_single(y_true, y_pred, a=1.0, **kwargs):
         (
             partial(ufl.tweedie_deviance, power=2),
             partial(tweedie_deviance_single, power=2),
+        ),
+        (
+            partial(ufl.tweedie_deviance, power=1.5),
+            partial(tweedie_deviance_single, power=1.5),
+        ),
+        (
+            partial(ufl.tweedie_deviance, power=2.5),
+            partial(tweedie_deviance_single, power=2.5),
         ),
     ],
 )

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -1232,9 +1232,12 @@ def tweedie_deviance(
 
         def gen_expr(model):
             return (
-                2 * (nw.col(model).log() - nw.col(target_col).log())
-                + (nw.col(target_col) / nw.col(model))
-                - 1
+                2
+                * (
+                    (nw.col(model).log() - nw.col(target_col).log())
+                    + (nw.col(target_col) / nw.col(model))
+                    - 1
+                )
             ).alias(model)
 
     else:
@@ -1245,9 +1248,13 @@ def tweedie_deviance(
                 * (
                     nw.col(target_col).clip(0) ** (2 - power)
                     / ((1 - power) * (2 - power))
+                    - (
+                        nw.col(target_col)
+                        * (nw.col(model) ** (1 - power))
+                        / (1 - power)
+                    )
+                    + (nw.col(model) ** (2 - power) / (2 - power))
                 )
-                - (nw.col(target_col) * (nw.col(model) ** (1 - power)) / (1 - power))
-                + (nw.col(model) ** (2 - power) / (2 - power))
             ).alias(model)
 
     return _nw_agg_expr(


### PR DESCRIPTION
## Problem

For a general Tweedie `power` (and for the `power == 2` gamma case), the factor
of 2 was only applied to the first deviance term:

```python
2 * ( y^(2-p) / ((1-p)(2-p)) )   # only this term is doubled
- ( y * m^(1-p) / (1-p) )        # not doubled
+ ( m^(2-p) / (2-p) )            # not doubled
```

The unit Tweedie deviance doubles all three terms. Because of this, the result
was wrong for every power other than 0 and 1, and even negative for
`1 < power < 2` (a deviance can never be negative).

```
power=1.5: tweedie_deviance = -6.67   sklearn mean_tweedie_deviance = 0.066
power=2.0: tweedie_deviance =  0.069   sklearn                       = 0.045
```

The bug went unnoticed because the loss comparison test only covered powers 0,
1 and 2, and its own reference for `power == 2` repeated the same mistake.

## Fix

Distribute the `2 *` over all three terms in both the general-power branch and
the `power == 2` branch.

## Verification

After the fix, `tweedie_deviance` matches `sklearn.metrics.mean_tweedie_deviance`
for powers 0, 1, 1.2, 1.5, 1.8, 2.0, 2.5 and 3.0 (max abs diff < 1e-6). The test
reference for `power == 2` is corrected to the same formula, and general-power
cases (1.5 and 2.5) are added to `test_loss`, which fail without the code change
and pass with it. The full `test_losses.py` suite (106 tests, pandas and polars)
passes.
