### PR TITLE
docs: fix remaining language errors

### DIFF
--- a/utilsforecast/plotting.py
+++ b/utilsforecast/plotting.py
@@ -97,7 +97,7 @@ def plot_series(
         seed (int, optional): Seed used for the random number generator. Only
             used if plot_random is True. Defaults to 0.
         resampler_kwargs (dict, optional): Keyword arguments to be passed to
-            plotly-resampler constructor. For further custumization ("show_dash")
+            plotly-resampler constructor. For further customization ("show_dash")
             call the method, store the plotting object and add the extra arguments
             to its `show_dash` method. Defaults to None.
         ax (matplotlib axes, array of matplotlib axes or plotly Figure, optional):


### PR DESCRIPTION
## What

Fix one objective spelling error in the Plotly resampler parameter documentation.

## Why

The generated UtilsForecast plotting reference contains a visible misspelling. The correction preserves the technical meaning.

## How

1. Change custumization to customization in the plotting docstring.

## Testing

1. [x] Confirmed the reported misspelling is absent from the affected file.
2. [x] Reviewed the complete diff.
3. [x] Confirmed no secrets, credentials, or generated binaries are included.

## Checklist

1. [x] The title follows the conventional commit format.
2. [x] The pull request is focused on one concern.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data are included.