### PR TITLE
Use id_col when joining cutoffs in the scaled losses

### DIFF
--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -591,8 +591,8 @@ class TestTweedieDeviance:
             )
 
 
-@pytest.mark.parametrize("metric", [ufl.mase, ufl.msse, ufl.rmsse])
-def test_scaled_metrics_with_cutoffs_respect_id_col(metric):
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_scaled_metric_with_cutoffs_respects_id_col(engine):
     # Cross-validation output carries a `cutoff` column. The scaled metrics
     # must honour a non-default `id_col` there, and give the same numbers as
     # they do for the default one.
@@ -613,15 +613,20 @@ def test_scaled_metrics_with_cutoffs_respect_id_col(metric):
                 "y": [8.0, 9.0, 18.0, 19.0],
             }
         )
+        if engine == "polars":
+            import polars as pl
+
+            df = pl.from_pandas(df)
+            train_df = pl.from_pandas(train_df)
         return df, train_df
 
     default_df, default_train = frames("unique_id")
     renamed_df, renamed_train = frames("item_id")
 
-    expected = metric(
+    expected = ufl.mase(
         default_df, models=["model"], seasonality=1, train_df=default_train
     )
-    actual = metric(
+    actual = ufl.mase(
         renamed_df,
         models=["model"],
         seasonality=1,

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -589,3 +589,44 @@ class TestTweedieDeviance:
             assert td_nw[col].null_count() == 0, (
                 f"NaNs found in {engine} DataFrame for power {power}"
             )
+
+
+@pytest.mark.parametrize("metric", [ufl.mase, ufl.msse, ufl.rmsse])
+def test_scaled_metrics_with_cutoffs_respect_id_col(metric):
+    # Cross-validation output carries a `cutoff` column. The scaled metrics
+    # must honour a non-default `id_col` there, and give the same numbers as
+    # they do for the default one.
+    def frames(id_col):
+        df = pd.DataFrame(
+            {
+                id_col: ["a", "a", "b", "b"],
+                "ds": pd.to_datetime(["2024-01-03", "2024-01-04"] * 2),
+                "cutoff": pd.to_datetime(["2024-01-02"] * 4),
+                "y": [10.0, 11.0, 20.0, 21.0],
+                "model": [10.5, 11.5, 20.5, 21.5],
+            }
+        )
+        train_df = pd.DataFrame(
+            {
+                id_col: ["a", "a", "b", "b"],
+                "ds": pd.to_datetime(["2024-01-01", "2024-01-02"] * 2),
+                "y": [8.0, 9.0, 18.0, 19.0],
+            }
+        )
+        return df, train_df
+
+    default_df, default_train = frames("unique_id")
+    renamed_df, renamed_train = frames("item_id")
+
+    expected = metric(
+        default_df, models=["model"], seasonality=1, train_df=default_train
+    )
+    actual = metric(
+        renamed_df,
+        models=["model"],
+        seasonality=1,
+        train_df=renamed_train,
+        id_col="item_id",
+    )
+
+    np.testing.assert_allclose(actual["model"].to_numpy(), expected["model"].to_numpy())

--- a/utilsforecast/losses.py
+++ b/utilsforecast/losses.py
@@ -97,7 +97,7 @@ def _create_train_with_cutoffs(
 
     if cutoff_col in group_cols:
         cutoffs_df = nw.from_native(df).select(*group_cols).unique()
-        train_df = train_df.join(cutoffs_df, on="unique_id", how="inner").filter(
+        train_df = train_df.join(cutoffs_df, on=id_col, how="inner").filter(
             nw.col(time_col) <= nw.col(cutoff_col)
         )
 


### PR DESCRIPTION
`_create_train_with_cutoffs` resolves its group columns from `id_col`, but then hardcodes `"unique_id"` in the join:

```python
group_cols = _get_group_cols(df=df, id_col=id_col, cutoff_col=cutoff_col)
...
if cutoff_col in group_cols:
    cutoffs_df = nw.from_native(df).select(*group_cols).unique()
    train_df = train_df.join(cutoffs_df, on="unique_id", how="inner").filter(...)
```

So every scaled metric fails on cross-validation output (which carries a `cutoff` column) when `id_col` is anything other than `unique_id`:

```python
mase(df, models=["model"], seasonality=1, train_df=train_df, id_col="item_id")
# KeyError: ['unique_id']
```

That covers `mase`, `msse`, `rmsse`, `spis`, `scaled_quantile_loss` and `scaled_mqloss`, and `evaluate` on top of them. Since `cross_validation` in both `mlforecast` and `neuralforecast` emits a `cutoff` column and both accept a custom `id_col`, this is reachable from a standard pipeline.

Joining on `id_col` fixes it, and gives the invariant you'd expect — renaming the id column changes nothing:

| metric | `id_col="unique_id"` | `id_col="item_id"` before | after |
|---|---|---|---|
| `mase` | `[0.5, 0.5]` | `KeyError` | `[0.5, 0.5]` |
| `msse` | `[0.25, 0.25]` | `KeyError` | `[0.25, 0.25]` |
| `rmsse` | `[0.5, 0.5]` | `KeyError` | `[0.5, 0.5]` |

The default `unique_id` path is unaffected.

Added a parametrised regression test covering `mase`/`msse`/`rmsse` with a `cutoff` column and a renamed id column, asserting it matches the default-`id_col` result. It fails 3/3 on `main` and passes here. `tests/test_losses.py` previously had no `cutoff` coverage at all, which is why this went unnoticed.
