### PR TITLE
fix: Issue with plotly engine 

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -98,6 +98,21 @@ def test_plot_series(set_series, set_paths):
     fig.savefig(set_paths / "plotting.png", bbox_inches="tight")
 
 
+@pytest.mark.skipif(not PLOTLY_INSTALLED, reason="plotly is not installed")
+def test_plot_series_plotly_many_series():
+    "test that the plotly engine works for multiple series"
+    series = generate_series(15, freq="D", equal_ends=True)
+
+    fig = plot_series(
+        series,
+        plot_random=False,
+        max_ids=15,
+        engine="plotly",
+    )
+
+    assert len(fig.data) == 15
+
+
 @pytest.mark.parametrize(
     "as_polars,ids,plot_anomalies,level,max_insample_length,engine,plot_random,with_forecasts",
     get_plotting_combinations(),

--- a/utilsforecast/plotting.py
+++ b/utilsforecast/plotting.py
@@ -239,11 +239,12 @@ def plot_series(
     if ax is None:
         postprocess = True
         if engine.startswith("plotly"):
-            vertical_spacing = 0.3 / n_rows
             fig = make_subplots(
                 rows=n_rows,
                 cols=n_cols,
-                vertical_spacing=vertical_spacing,
+                vertical_spacing=(
+                    min(0.15, 0.9 / (n_rows - 1)) if n_rows > 1 else 0.15
+                ),
                 horizontal_spacing=0.07,
                 x_title=xlabel,
                 y_title=ylabel,

--- a/utilsforecast/plotting.py
+++ b/utilsforecast/plotting.py
@@ -242,9 +242,7 @@ def plot_series(
             fig = make_subplots(
                 rows=n_rows,
                 cols=n_cols,
-                vertical_spacing=(
-                    min(0.15, 0.9 / (n_rows - 1)) if n_rows > 1 else 0.15
-                ),
+                vertical_spacing=0.3 / n_rows,
                 horizontal_spacing=0.07,
                 x_title=xlabel,
                 y_title=ylabel,

--- a/utilsforecast/plotting.py
+++ b/utilsforecast/plotting.py
@@ -239,10 +239,11 @@ def plot_series(
     if ax is None:
         postprocess = True
         if engine.startswith("plotly"):
+            vertical_spacing = 0.3 / n_rows
             fig = make_subplots(
                 rows=n_rows,
                 cols=n_cols,
-                vertical_spacing=0.15,
+                vertical_spacing=vertical_spacing,
                 horizontal_spacing=0.07,
                 x_title=xlabel,
                 y_title=ylabel,


### PR DESCRIPTION
## Description

Currently, the `vertical_spacing` of the plot grid is fixed at 0.15. Plotly requires that `vertical_spacing <= 1 / (rows - 1)`. For eight rows (more than 14 series), the maximum is 1 / 7 = 0.14, so 0.15 is invalid. 

This PR calculates `vertical_spacing` dynamically based on the number of rows, while keeping it below Plotly’s limit.

Plotly's `vertical_spacing` restriction: https://github.com/plotly/plotly.py/blob/15f33d22a21cbdc83747ed4d14482d00f24d185f/plotly/_subplots.py#L531

## Reproducible example 

```python
import pandas as pd 
from utilsforecast.plotting import plot_series 
df = pd.read_parquet('https://datasets-nixtla.s3.amazonaws.com/m4-hourly.parquet') # contains 414 series
plot_series(df, max_ids=15, engine='plotly') # should no longer raise an error
```


